### PR TITLE
Small optimizations and fix pointer aliasing

### DIFF
--- a/Src/Graphics/Legacy3D/Legacy3D.cpp
+++ b/Src/Graphics/Legacy3D/Legacy3D.cpp
@@ -688,9 +688,9 @@ void CLegacy3D::DescendCullingNode(UINT32 addr)
   const UINT32 node1Ptr     = node[0x07-offset];
   const UINT32 node2Ptr     = node[0x08-offset];
   const UINT32 matrixOffset = node[0x03-offset]&0xFFF;
-  const float x             = *(float *) &node[0x04-offset];
-  const float y             = *(float *) &node[0x05-offset];
-  const float z             = *(float *) &node[0x06-offset];
+  const float x             = Util::Uint32AsFloat(node[0x04-offset]);
+  const float y             = Util::Uint32AsFloat(node[0x05-offset]);
+  const float z             = Util::Uint32AsFloat(node[0x06-offset]);
   
   // Texture offset?
   TextureOffset oldTextureOffset = m_textureOffset; // save old offsets

--- a/Src/Graphics/Legacy3D/Legacy3D.cpp
+++ b/Src/Graphics/Legacy3D/Legacy3D.cpp
@@ -161,6 +161,7 @@
 #include "Supermodel.h"
 #include "Shaders3D.h"  // fragment and vertex shaders
 #include "Graphics/Shader.h"
+#include "Util/BitCast.h"
 
 #include <algorithm>
 #include <cmath>
@@ -851,8 +852,8 @@ void CLegacy3D::RenderViewport(UINT32 addr, int pri, bool wideScreen)
   int vpHeight  = (vpnode[0x14]>>18)&0x3FFF;  // height (14.2)
   
   // Field of view and clipping
-  GLfloat vpTopAngle  = asinf(uint_as_float(vpnode[0x0E]));  // FOV Y upper half-angle (radians)
-  GLfloat vpBotAngle  = asinf(uint_as_float(vpnode[0x12]));  // FOV Y lower half-angle
+  GLfloat vpTopAngle  = asinf(Util::UintAsFloat(vpnode[0x0E]));  // FOV Y upper half-angle (radians)
+  GLfloat vpBotAngle  = asinf(Util::UintAsFloat(vpnode[0x12]));  // FOV Y lower half-angle
   GLfloat fovYDegrees = (vpTopAngle+vpBotAngle)*(float)(180.0/M_PI);
   // TO-DO: investigate clipping planes
   

--- a/Src/Graphics/Legacy3D/Models.cpp
+++ b/Src/Graphics/Legacy3D/Models.cpp
@@ -725,7 +725,7 @@ void CLegacy3D::InsertVertex(ModelCache *Cache, const Vertex *V, const Poly *P, 
   // Specular shininess
   GLfloat specularCoefficient = (GLfloat) ((P->header[0]>>26) & 0x3F) * (1.0f/63.0f);
   int shinyBits = (P->header[6] >> 5) & 3;
-  float shininess = std::pow(2.0f, 1.f + shinyBits);
+  float shininess = std::exp2f(1 + shinyBits);
   if (!(P->header[0]&0x80)) //|| (shininess == 0)) // bit 0x80 seems to enable specular lighting
   {
     specularCoefficient = 0.; // disable
@@ -1224,7 +1224,7 @@ bool CLegacy3D::CreateModelCache(ModelCache *Cache, unsigned vboMaxVerts,
   {
     // Last ditch attempt: try the local buffer size
     vboBytes = localBytes;
-    glBufferData(GL_ARRAY_BUFFER, vboBytes, 0, isDynamic?GL_STREAM_DRAW:GL_STATIC_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, vboBytes, nullptr, isDynamic?GL_STREAM_DRAW:GL_STATIC_DRAW);
     if (glGetError() != GL_NO_ERROR)
       return ErrorLog("OpenGL was unable to provide a %s vertex buffer.", isDynamic?"dynamic":"static");
   }

--- a/Src/Graphics/New3D/Mat4.cpp
+++ b/Src/Graphics/New3D/Mat4.cpp
@@ -3,7 +3,7 @@
 #include <utility>
 
 #ifndef M_PI
-#define M_PI 3.14159265359
+#define M_PI 3.1415926535897932384626433832795
 #endif
 
 namespace New3D {
@@ -17,10 +17,10 @@ void Mat4::LoadIdentity()
 {
 	float *m = currentMatrix;
 
-	m[0] = 1; m[4] = 0; m[8 ] = 0; m[12] = 0;
-	m[1] = 0; m[5] = 1; m[9 ] = 0; m[13] = 0;
-	m[2] = 0; m[6] = 0; m[10] = 1; m[14] = 0;
-	m[3] = 0; m[7] = 0; m[11] = 0; m[15] = 1;
+	m[0] = 1.f; m[4] = 0.f; m[8 ] = 0.f; m[12] = 0.f;
+	m[1] = 0.f; m[5] = 1.f; m[9 ] = 0.f; m[13] = 0.f;
+	m[2] = 0.f; m[6] = 0.f; m[10] = 1.f; m[14] = 0.f;
+	m[3] = 0.f; m[7] = 0.f; m[11] = 0.f; m[15] = 1.f;
 }
 
 void Mat4::MultiMatrices(const float a[16], const float b[16], float r[16]) 
@@ -29,8 +29,7 @@ void Mat4::MultiMatrices(const float a[16], const float b[16], float r[16])
 #define B(row,col)  b[(col<<2)+row]
 #define P(row,col)  r[(col<<2)+row]
 
-	int i;
-	for (i = 0; i < 4; i++) {
+	for (int i = 0; i < 4; i++) {
 		const float ai0 = A(i, 0), ai1 = A(i, 1), ai2 = A(i, 2), ai3 = A(i, 3);
 		P(i, 0) = ai0 * B(0, 0) + ai1 * B(1, 0) + ai2 * B(2, 0) + ai3 * B(3, 0);
 		P(i, 1) = ai0 * B(0, 1) + ai1 * B(1, 1) + ai2 * B(2, 1) + ai3 * B(3, 1);
@@ -56,25 +55,25 @@ void Mat4::Translate(float x, float y, float z)
 	float m[16];
 	//==========
 
-	m[0] = 1;
-	m[1] = 0;
-	m[2] = 0;
-	m[3] = 0;
+	m[0] = 1.f;
+	m[1] = 0.f;
+	m[2] = 0.f;
+	m[3] = 0.f;
 
-	m[4] = 0;
-	m[5] = 1;
-	m[6] = 0;
-	m[7] = 0;
+	m[4] = 0.f;
+	m[5] = 1.f;
+	m[6] = 0.f;
+	m[7] = 0.f;
 
-	m[8] = 0;
-	m[9] = 0;
-	m[10] = 1;
-	m[11] = 0;
+	m[8] = 0.f;
+	m[9] = 0.f;
+	m[10] = 1.f;
+	m[11] = 0.f;
 
 	m[12] = x;
 	m[13] = y;
 	m[14] = z;
-	m[15] = 1;
+	m[15] = 1.f;
 
 	Mat4::MultiMatrices(currentMatrix, m, currentMatrix);
 }
@@ -86,155 +85,137 @@ void Mat4::Scale(float x, float y, float z)
 	//==========
 
 	m[0] = x;
-	m[1] = 0;
-	m[2] = 0;
-	m[3] = 0;
+	m[1] = 0.f;
+	m[2] = 0.f;
+	m[3] = 0.f;
 
-	m[4] = 0;
+	m[4] = 0.f;
 	m[5] = y;
-	m[6] = 0;
-	m[7] = 0;
+	m[6] = 0.f;
+	m[7] = 0.f;
 
-	m[8] = 0;
-	m[9] = 0;
+	m[8] = 0.f;
+	m[9] = 0.f;
 	m[10] = z;
-	m[11] = 0;
+	m[11] = 0.f;
 
-	m[12] = 0;
-	m[13] = 0;
-	m[14] = 0;
-	m[15] = 1;
+	m[12] = 0.f;
+	m[13] = 0.f;
+	m[14] = 0.f;
+	m[15] = 1.f;
 
 	Mat4::MultiMatrices(currentMatrix, m, currentMatrix);
 }
 
 void Mat4::Rotate(float angle, float x, float y, float z) 
 {
-	//===========
-	float c;
-	float s;
-	float m[16];
-	//===========
-
 	// normalise vector first
 	{
 		//========
-		float len;
+		float inv_len;
 		//========
 
-		len = std::sqrt(x * x + y * y + z * z);
+		inv_len = 1.f/std::sqrt(x * x + y * y + z * z);
 		
-		x /= len;
-		y /= len;
-		z /= len;
+		x *= inv_len;
+		y *= inv_len;
+		z *= inv_len;
 	}
 
-	c = std::cos(angle*3.14159265f / 180.0f);
-	s = std::sin(angle*3.14159265f / 180.0f);
+	float c = std::cos(angle*(float)(M_PI / 180.0));
+	float s = std::sin(angle*(float)(M_PI / 180.0));
 
-	m[0] = (x*x) * (1 - c) + c;
-	m[1] = (y*x) * (1 - c) + (z*s);
-	m[2] = (x*z) * (1 - c) - (y*s);
-	m[3] = 0;
+	float m[16];
+	m[0] = (x*x) * (1.f - c) + c;
+	m[1] = (y*x) * (1.f - c) + (z*s);
+	m[2] = (x*z) * (1.f - c) - (y*s);
+	m[3] = 0.f;
 
-	m[4] = (x*y) * (1 - c) - (z*s);
-	m[5] = (y*y) * (1 - c) + c;
-	m[6] = (y*z) * (1 - c) + (x*s);
-	m[7] = 0;
+	m[4] = (x*y) * (1.f - c) - (z*s);
+	m[5] = (y*y) * (1.f - c) + c;
+	m[6] = (y*z) * (1.f - c) + (x*s);
+	m[7] = 0.f;
 
-	m[8] = (x*z) * (1 - c) + (y*s);
-	m[9] = (y*z) * (1 - c) - (x*s);
-	m[10] = (z*z) * (1 - c) + c;
-	m[11] = 0;
+	m[8] = (x*z) * (1.f - c) + (y*s);
+	m[9] = (y*z) * (1.f - c) - (x*s);
+	m[10] = (z*z) * (1.f - c) + c;
+	m[11] = 0.f;
 
-	m[12] = 0;
-	m[13] = 0;
-	m[14] = 0;
-	m[15] = 1;
+	m[12] = 0.f;
+	m[13] = 0.f;
+	m[14] = 0.f;
+	m[15] = 1.f;
 
 	Mat4::MultiMatrices(currentMatrix, m, currentMatrix);
 }
 
 void Mat4::Frustum(float left, float right, float bottom, float top, float nearVal, float farVal) 
 {
-	//=====================
+	float x = (2.0F*nearVal) / (right - left);
+	float y = (2.0F*nearVal) / (top - bottom);
+	float a = (right + left) / (right - left);
+	float b = (top + bottom) / (top - bottom);
+	float c = -(farVal + nearVal) / (farVal - nearVal);
+	float d = -(2.0F*farVal*nearVal) / (farVal - nearVal);
+
 	float m[16];
-	float x, y, a, b, c, d;
-	//=====================
-
-	x = (2.0F*nearVal) / (right - left);
-	y = (2.0F*nearVal) / (top - bottom);
-	a = (right + left) / (right - left);
-	b = (top + bottom) / (top - bottom);
-	c = -(farVal + nearVal) / (farVal - nearVal);
-	d = -(2.0F*farVal*nearVal) / (farVal - nearVal);
-
 	m[0] = x;
-	m[1] = 0;
-	m[2] = 0;
-	m[3] = 0;
+	m[1] = 0.f;
+	m[2] = 0.f;
+	m[3] = 0.f;
 
-	m[4] = 0;
+	m[4] = 0.f;
 	m[5] = y;
-	m[6] = 0;
-	m[7] = 0;
+	m[6] = 0.f;
+	m[7] = 0.f;
 
 	m[8] = a;
 	m[9] = b;
 	m[10] = c;
-	m[11] = -1;
+	m[11] = -1.f;
 
-	m[12] = 0;
-	m[13] = 0;
+	m[12] = 0.f;
+	m[13] = 0.f;
 	m[14] = d;
-	m[15] = 0;
+	m[15] = 0.f;
 
 	Mat4::MultiMatrices(currentMatrix, m, currentMatrix);
 }
 
 void Mat4::Perspective(float fovy, float aspect, float zNear, float zFar)
 {
-	//=========
-	float ymax;
-	float xmax;
-	//=========
-
-	ymax = zNear * tanf(fovy * (float)M_PI / 360.0f);
-	xmax = ymax * aspect;
+	float ymax = zNear * tanf(fovy * (float)(M_PI / 360.0));
+	float xmax = ymax * aspect;
 
 	Frustum(-xmax, xmax, -ymax, ymax, zNear, zFar);
 }
 
 void Mat4::Ortho(float left, float right, float bottom, float top, float nearVal, float farVal)
 {
-	//================
+	float tx = -(right + left) / (right - left);
+	float ty = -(top + bottom) / (top - bottom);
+	float tz = -(farVal + nearVal) / (farVal - nearVal);
+
 	float m[16];
-	float tx, ty, tz;
-	//================
+	m[0] = 2.f/(right-left);
+	m[1] = 0.f;
+	m[2] = 0.f;
+	m[3] = 0.f;
 
-	tx = -(right + left) / (right - left);
-	ty = -(top + bottom) / (top - bottom);
-	tz = -(farVal + nearVal) / (farVal - nearVal);
+	m[4] = 0.f;
+	m[5] = 2.f/(top-bottom);
+	m[6] = 0.f;
+	m[7] = 0.f;
 
-	m[0] = 2/(right-left);
-	m[1] = 0;
-	m[2] = 0;
-	m[3] = 0;
-
-	m[4] = 0;
-	m[5] = 2/(top-bottom);
-	m[6] = 0;
-	m[7] = 0;
-
-	m[8] = 0;
-	m[9] = 0;
-	m[10] = -2/(farVal-nearVal);
-	m[11] = 0;
+	m[8] = 0.f;
+	m[9] = 0.f;
+	m[10] = -2.f/(farVal-nearVal);
+	m[11] = 0.f;
 
 	m[12] = tx;
 	m[13] = ty;
 	m[14] = tz;
-	m[15] = 1;
+	m[15] = 1.f;
 
 	Mat4::MultiMatrices(currentMatrix, m, currentMatrix);
 }

--- a/Src/Graphics/New3D/New3D.cpp
+++ b/Src/Graphics/New3D/New3D.cpp
@@ -553,8 +553,8 @@ void CNew3D::DescendCullingNode(UINT32 addr)
 	m_nodeAttribs.Push();	// save current attribs
 
 	if (!m_offset) {		// Step 1.5+
-		
-		float modelScale = Util::UintAsFloat(node[1]);
+
+		float modelScale = Util::Uint32AsFloat(node[1]);
 		if (modelScale > std::numeric_limits<float>::min()) {
 			m_nodeAttribs.currentModelScale = modelScale;
 		}
@@ -574,9 +574,9 @@ void CNew3D::DescendCullingNode(UINT32 addr)
 
 	// apply translation vector
 	if (node[0x00] & 0x10) {
-		float x = Util::UintAsFloat(node[0x04 - m_offset]);
-		float y = Util::UintAsFloat(node[0x05 - m_offset]);
-		float z = Util::UintAsFloat(node[0x06 - m_offset]);
+		float x = Util::Uint32AsFloat(node[0x04 - m_offset]);
+		float y = Util::Uint32AsFloat(node[0x05 - m_offset]);
+		float z = Util::Uint32AsFloat(node[0x06 - m_offset]);
 		m_modelMat.Translate(x, y, z);
 	}
 	// multiply matrix, if specified
@@ -832,16 +832,16 @@ void CNew3D::RenderViewport(UINT32 addr)
 		m_LODBlendTable = (LODBlendTable*)TranslateCullingAddress(vpnode[0x17] & 0xFFFFFF);
 
 		/*
-		vp->angle_left		= -atan2f(Util::UintAsFloat(vpnode[12]),  Util::UintAsFloat(vpnode[13]));	// These values work out as the normals for the clipping planes.
-		vp->angle_right		=  atan2f(Util::UintAsFloat(vpnode[16]), -Util::UintAsFloat(vpnode[17]));	// Sometimes these values (dirt devils,lost world) are totally wrong
-		vp->angle_top		=  atan2f(Util::UintAsFloat(vpnode[14]),  Util::UintAsFloat(vpnode[15]));	// and don't work for the frustum values exactly.
-		vp->angle_bottom	= -atan2f(Util::UintAsFloat(vpnode[18]), -Util::UintAsFloat(vpnode[19]));	// Perhaps they are just used for culling and not rendering.
+		vp->angle_left		= -atan2f(Util::Uint32AsFloat(vpnode[12]),  Util::Uint32AsFloat(vpnode[13]));	// These values work out as the normals for the clipping planes.
+		vp->angle_right		=  atan2f(Util::Uint32AsFloat(vpnode[16]), -Util::Uint32AsFloat(vpnode[17]));	// Sometimes these values (dirt devils,lost world) are totally wrong
+		vp->angle_top		=  atan2f(Util::Uint32AsFloat(vpnode[14]),  Util::Uint32AsFloat(vpnode[15]));	// and don't work for the frustum values exactly.
+		vp->angle_bottom	= -atan2f(Util::Uint32AsFloat(vpnode[18]), -Util::Uint32AsFloat(vpnode[19]));	// Perhaps they are just used for culling and not rendering.
 		*/
 
-		float cv = Util::UintAsFloat(vpnode[0x8]);	// 1/(left-right)
-		float cw = Util::UintAsFloat(vpnode[0x9]);	// 1/(top-bottom)
-		float io = Util::UintAsFloat(vpnode[0xa]);	// top / bottom (ratio) - ish
-		float jo = Util::UintAsFloat(vpnode[0xb]);	// left / right (ratio)
+		float cv = Util::Uint32AsFloat(vpnode[0x8]);	// 1/(left-right)
+		float cw = Util::Uint32AsFloat(vpnode[0x9]);	// 1/(top-bottom)
+		float io = Util::Uint32AsFloat(vpnode[0xa]);	// top / bottom (ratio) - ish
+		float jo = Util::Uint32AsFloat(vpnode[0xb]);	// left / right (ratio)
 
 		vp->angle_left		= (0.0f - jo) / cv;
 		vp->angle_right		= (1.0f - jo) / cv;
@@ -855,10 +855,10 @@ void CNew3D::RenderViewport(UINT32 addr)
 		CalcFrustumPlanes(m_planes, vp->projectionMatrix);	// we need to calc a 'projection matrix' to get the correct frustum planes for clipping
 
 		// Lighting (note that sun vector points toward sun -- away from vertex)
-		vp->lightingParams[0] =  Util::UintAsFloat(vpnode[0x05]);							// sun X
-		vp->lightingParams[1] = -Util::UintAsFloat(vpnode[0x06]);							// sun Y (- to convert to ogl cordinate system)
-		vp->lightingParams[2] = -Util::UintAsFloat(vpnode[0x04]);							// sun Z (- to convert to ogl cordinate system)
-		vp->lightingParams[3] = std::max(0.f, std::min(Util::UintAsFloat(vpnode[0x07]), 1.0f));	// sun intensity (clamp to 0-1)
+		vp->lightingParams[0] =  Util::Uint32AsFloat(vpnode[0x05]);							// sun X
+		vp->lightingParams[1] = -Util::Uint32AsFloat(vpnode[0x06]);							// sun Y (- to convert to ogl cordinate system)
+		vp->lightingParams[2] = -Util::Uint32AsFloat(vpnode[0x04]);							// sun Z (- to convert to ogl cordinate system)
+		vp->lightingParams[3] = std::max(0.f, std::min(Util::Uint32AsFloat(vpnode[0x07]), 1.0f));	// sun intensity (clamp to 0-1)
 		vp->lightingParams[4] = (float)((vpnode[0x24] >> 8) & 0xFF) * (float)(1.0 / 255.0);	// ambient intensity
 		vp->lightingParams[5] = 0.0f;	// reserved
 		
@@ -874,8 +874,8 @@ void CNew3D::RenderViewport(UINT32 addr)
 		vp->spotEllipse[2] = (float)((vpnode[0x1E] >> 16) & 0xFFFF);					// spotlight X size (16-bit)
 		vp->spotEllipse[3] = (float)((vpnode[0x1D] >> 16) & 0xFFFF);					// spotlight Y size
 
-		vp->spotRange[0] = 1.0f / Util::UintAsFloat(vpnode[0x21]);						// spotlight start
-		vp->spotRange[1] = Util::UintAsFloat(vpnode[0x1F]);								// spotlight extent
+		vp->spotRange[0] = 1.0f / Util::Uint32AsFloat(vpnode[0x21]);					// spotlight start
+		vp->spotRange[1] = Util::Uint32AsFloat(vpnode[0x1F]);							// spotlight extent
 
 		vp->spotColor[0] = color[spotColorIdx][0];										// spotlight color
 		vp->spotColor[1] = color[spotColorIdx][1];
@@ -909,7 +909,7 @@ void CNew3D::RenderViewport(UINT32 addr)
 		vp->fogParams[0] = (float)((vpnode[0x22] >> 16) & 0xFF) * (float)(1.0 / 255.0);	// fog color R
 		vp->fogParams[1] = (float)((vpnode[0x22] >> 8) & 0xFF) * (float)(1.0 / 255.0);	// fog color G
 		vp->fogParams[2] = (float)((vpnode[0x22] >> 0) & 0xFF) * (float)(1.0 / 255.0);	// fog color B
-		vp->fogParams[3] = std::abs(Util::UintAsFloat(vpnode[0x23]));					// fog density	- ocean hunter uses negative values, but looks the same
+		vp->fogParams[3] = std::abs(Util::Uint32AsFloat(vpnode[0x23]));					// fog density	- ocean hunter uses negative values, but looks the same
 		vp->fogParams[4] = (float)(INT16)(vpnode[0x25] & 0xFFFF)* (float)(1.0 / 255.0);	// fog start
 
 		// Avoid Infinite and NaN values for Star Wars Trilogy

--- a/Src/Graphics/New3D/New3D.h
+++ b/Src/Graphics/New3D/New3D.h
@@ -183,7 +183,7 @@ public:
 	* Parameters:
 	*   config  Run-time configuration.
 	*/
-	CNew3D(const Util::Config::Node &config, std::string gameName);
+	CNew3D(const Util::Config::Node &config, const std::string& gameName);
 	~CNew3D(void);
 
 private:
@@ -305,7 +305,7 @@ private:
 	void CalcBox			(float distance, BBox& box);
 	void TransformBox		(const float *m, BBox& box);
 	void MultVec			(const float matrix[16], const float in[4], float out[4]);
-	Clip ClipBox			(BBox& box, Plane planes[5]);
+	Clip ClipBox			(const BBox& box, Plane planes[5]);
 	void ClipModel			(const Model *m);
 	void ClipPolygon		(ClipPoly& clipPoly, Plane planes[5]);
 	void CalcBoxExtents		(const BBox& box);

--- a/Src/Graphics/New3D/Plane.h
+++ b/Src/Graphics/New3D/Plane.h
@@ -8,11 +8,11 @@ struct Plane
 	float a, b, c, d;
 
 	void Normalise() {
-		float temp = std::sqrt((a * a) + (b * b) + (c * c));
-		a /= temp;
-		b /= temp;
-		c /= temp;
-		d /= temp;
+		float temp = 1.f/std::sqrt((a * a) + (b * b) + (c * c));
+		a *= temp;
+		b *= temp;
+		c *= temp;
+		d *= temp;
 	}
 
 	float DistanceToPoint(const float v[3]) {

--- a/Src/Graphics/New3D/R3DFloat.cpp
+++ b/Src/Graphics/New3D/R3DFloat.cpp
@@ -35,5 +35,5 @@ UINT32 R3DFloat::Convert16BitProFloat(UINT32 a1)
 
 float R3DFloat::ToFloat(UINT32 a1)
 {
-	return Util::UintAsFloat(a1);
+	return Util::Uint32AsFloat(a1);
 }

--- a/Src/Graphics/New3D/R3DFloat.cpp
+++ b/Src/Graphics/New3D/R3DFloat.cpp
@@ -1,5 +1,6 @@
 #include "Types.h"
 #include "R3DFloat.h"
+#include "Util\GenericValue.h"
 
 float R3DFloat::GetFloat16(UINT16 f)
 {
@@ -13,17 +14,16 @@ float R3DFloat::GetFloat32(UINT32 f)
 
 UINT32 R3DFloat::ConvertProFloat(UINT32 a1)
 {
-	int exponent = (a1 & 0x7E000000) >> 25;
+	UINT32 exponent = (a1 & 0x7E000000) >> 25;
 
 	if (exponent <= 31) {	// positive
 		exponent += 127;
 	}
 	else {					// negative exponent
-		exponent -= 64;
-		exponent += 127;
+		exponent += 127 - 64;
 	}
 
-	int mantissa = (a1 & 0x1FFFFFF) >> 2;
+	UINT32 mantissa = (a1 & 0x1FFFFFF) >> 2;
 
 	return (a1 & 0x80000000) | (exponent << 23) | mantissa;
 }
@@ -35,5 +35,5 @@ UINT32 R3DFloat::Convert16BitProFloat(UINT32 a1)
 
 float R3DFloat::ToFloat(UINT32 a1)
 {
-	return *(float*)(&a1);
+	return uint_as_float(a1);
 }

--- a/Src/Graphics/New3D/R3DFloat.cpp
+++ b/Src/Graphics/New3D/R3DFloat.cpp
@@ -1,6 +1,6 @@
 #include "Types.h"
 #include "R3DFloat.h"
-#include "Util/GenericValue.h"
+#include "Util/BitCast.h"
 
 float R3DFloat::GetFloat16(UINT16 f)
 {
@@ -35,5 +35,5 @@ UINT32 R3DFloat::Convert16BitProFloat(UINT32 a1)
 
 float R3DFloat::ToFloat(UINT32 a1)
 {
-	return uint_as_float(a1);
+	return Util::UintAsFloat(a1);
 }

--- a/Src/Graphics/New3D/R3DFloat.cpp
+++ b/Src/Graphics/New3D/R3DFloat.cpp
@@ -1,6 +1,6 @@
 #include "Types.h"
 #include "R3DFloat.h"
-#include "Util\GenericValue.h"
+#include "Util/GenericValue.h"
 
 float R3DFloat::GetFloat16(UINT16 f)
 {

--- a/Src/Graphics/New3D/R3DFloat.h
+++ b/Src/Graphics/New3D/R3DFloat.h
@@ -3,8 +3,8 @@
 
 namespace R3DFloat
 {
-	static const UINT16	Pro16BitMax = 0x7fff;
-	static const float	Pro16BitFltMin = 1e-7f;		// float min in IEEE 
+	constexpr UINT16	Pro16BitMax = 0x7fff;
+	constexpr float	Pro16BitFltMin = 1e-7f;			// float min in IEEE 
 
 	float	GetFloat16(UINT16 f);
 	float	GetFloat32(UINT32 f);

--- a/Src/Graphics/New3D/R3DFrameBuffers.h
+++ b/Src/Graphics/New3D/R3DFrameBuffers.h
@@ -37,7 +37,7 @@ private:
 			texCoords[1] = t;
 			verts[0] = x;
 			verts[1] = y;
-			verts[2] = 0;	// z = 0
+			verts[2] = 0.f;	// z = 0
 		}
 
 		float texCoords[2];

--- a/Src/Sound/SCSP.cpp
+++ b/Src/Sound/SCSP.cpp
@@ -602,7 +602,7 @@ void SCSP_StopSlot(_SLOT *slot,int keyoff)
 	//DebugLog("KEYOFF2 %d",slot->slot);
 }
 
-#define log2(n) (log((float) n)/log((float) 2))
+//#define log2(n) (log((float) n)/log((float) 2))
 
 bool SCSP_Init(const Util::Config::Node &config, int n)
 {
@@ -641,7 +641,7 @@ bool SCSP_Init(const Util::Config::Node &config, int n)
 	{
 		double fcent=(double) 1200.0*log2((double)(((double) 1024.0+(double)i)/(double)1024.0));
 		//float fcent=1.0+(float) i/1024.0;
-		fcent=(double) 44100.0*pow(2.0,fcent/1200.0);
+		fcent=(double) 44100.0*exp2(fcent/1200.0);
 		FNS_Table[i]=(UINT32)((float) (1<<SHIFT) *fcent);
 		//FNS_Table[i]=(i>>(10-SHIFT))|(1<<SHIFT);
 		
@@ -655,7 +655,7 @@ bool SCSP_Init(const Util::Config::Node &config, int n)
 #ifdef RB_VOLUME
 	// Volume table, 1 = -0.375dB, 8 = -3dB, 256 = -96dB
 	for (i = 0; i < 256; i++)
-		volume[i] = 65536.0*pow(2.0, (-0.375 / 6.0)*i);
+		volume[i] = 65536.0*exp2((-0.375 / 6.0)*i);
 	for (i = 256; i < 256 * 4; i++)
 		volume[i] = 0;
 

--- a/Src/Sound/SCSPLFO.cpp
+++ b/Src/Sound/SCSPLFO.cpp
@@ -42,10 +42,10 @@ struct _LFO
 #define LFIX(v)	((unsigned int) ((float) (1<<LFO_SHIFT)*(v)))
 
 //Convert DB to multiply amplitude
-#define DB(v) 	LFIX(pow(10.0,v/20.0))
+#define DB(v) 	LFIX(pow(10.0,(v)*(1.0/20.0)))
 
 //Convert cents to step increment
-#define CENTS(v) LFIX(pow(2.0,v/1200.0))
+#define CENTS(v) LFIX(exp2((v)*(1.0/1200.0)))
 
 static int PLFO_TRI[256], PLFO_SQR[256], PLFO_SAW[256], PLFO_NOI[256];
 static int ALFO_TRI[256], ALFO_SQR[256], ALFO_SAW[256], ALFO_NOI[256];
@@ -115,12 +115,12 @@ void LFO_Init(void)
 		float limit = PSCALE[s];
 		for (i = -128; i < 128; ++i)
 		{
-			PSCALES[s][i + 128] = CENTS(((limit*(float)i) / 128.0));
+			PSCALES[s][i + 128] = CENTS(((limit*(double)i) / 128.0));
 		}
 		limit = -ASCALE[s];
 		for (i = 0; i < 256; ++i)
 		{
-			ASCALES[s][i] = DB(((limit*(float)i) / 256.0));
+			ASCALES[s][i] = DB(((limit*(double)i) / 256.0));
 		}
 	}
 }

--- a/Src/Util/BitCast.h
+++ b/Src/Util/BitCast.h
@@ -1,0 +1,61 @@
+#ifndef INCLUDED_UTIL_BITCAST_H
+#define INCLUDED_UTIL_BITCAST_H
+
+#include <stdexcept>
+#include <cstring>
+
+namespace Util
+{
+#if __cplusplus >= 202002L
+#include <bit>
+#define FloatAsInt(x) std::bit_cast<int>(x)
+#define IntAsFloat(x) std::bit_cast<float>(x)
+#define UintAsFloat(x) std::bit_cast<float>(x)
+#elif 1
+template <class Dest, class Source>
+inline Dest bit_cast(Source const& source) {
+   static_assert(sizeof(Dest) == sizeof(Source), "size of destination and source objects must be equal");
+   static_assert(std::is_trivially_copyable<Dest>::value, "destination type must be trivially copyable.");
+   static_assert(std::is_trivially_copyable<Source>::value, "source type must be trivially copyable");
+
+   Dest dest;
+   std::memcpy(&dest, &source, sizeof(dest));
+   return dest;
+}
+#define FloatAsInt(x) bit_cast<int,float>(x)
+#define IntAsFloat(x) bit_cast<float,int>(x)
+#define UintAsFloat(x) bit_cast<float,unsigned int>(x)
+#else
+inline int FloatAsInt(const float x)
+{
+   union {
+      float f;
+      int i;
+   } uc;
+   uc.f = x;
+   return uc.i;
+}
+
+inline float IntAsFloat(const int i)
+{
+   union {
+      int i;
+      float f;
+   } iaf;
+   iaf.i = i;
+   return iaf.f;
+}
+
+inline float UintAsFloat(const unsigned int i)
+{
+   union {
+      unsigned int u;
+      float f;
+   } iaf;
+   iaf.u = i;
+   return iaf.f;
+}
+#endif
+} // Util
+
+#endif  // INCLUDED_UTIL_BITCAST_H

--- a/Src/Util/BitCast.h
+++ b/Src/Util/BitCast.h
@@ -8,10 +8,10 @@ namespace Util
 {
 #if __cplusplus >= 202002L
 #include <bit>
-#define FloatAsInt(x) std::bit_cast<int>(x)
-#define IntAsFloat(x) std::bit_cast<float>(x)
-#define UintAsFloat(x) std::bit_cast<float>(x)
-#elif 1
+#define FloatAsInt32(x) std::bit_cast<int32_t>(x)
+#define Int32AsFloat(x) std::bit_cast<float>(x)
+#define Uint32AsFloat(x) std::bit_cast<float>(x)
+#else
 template <class Dest, class Source>
 inline Dest bit_cast(Source const& source) {
    static_assert(sizeof(Dest) == sizeof(Source), "size of destination and source objects must be equal");
@@ -22,39 +22,9 @@ inline Dest bit_cast(Source const& source) {
    std::memcpy(&dest, &source, sizeof(dest));
    return dest;
 }
-#define FloatAsInt(x) bit_cast<int,float>(x)
-#define IntAsFloat(x) bit_cast<float,int>(x)
-#define UintAsFloat(x) bit_cast<float,unsigned int>(x)
-#else
-inline int FloatAsInt(const float x)
-{
-   union {
-      float f;
-      int i;
-   } uc;
-   uc.f = x;
-   return uc.i;
-}
-
-inline float IntAsFloat(const int i)
-{
-   union {
-      int i;
-      float f;
-   } iaf;
-   iaf.i = i;
-   return iaf.f;
-}
-
-inline float UintAsFloat(const unsigned int i)
-{
-   union {
-      unsigned int u;
-      float f;
-   } iaf;
-   iaf.u = i;
-   return iaf.f;
-}
+#define FloatAsInt32(x) bit_cast<int32_t,float>(x)
+#define Int32AsFloat(x) bit_cast<float,int32_t>(x)
+#define Uint32AsFloat(x) bit_cast<float,uint32_t>(x)
 #endif
 } // Util
 

--- a/Src/Util/GenericValue.h
+++ b/Src/Util/GenericValue.h
@@ -20,6 +20,57 @@
 #include <memory>
 #include <cctype>
 
+#if __cplusplus >= 202002L
+#include <bit>
+#define float_as_int(x) std::bit_cast<int>(x)
+#define int_as_float(x) std::bit_cast<float>(x)
+#define uint_as_float(x) std::bit_cast<float>(x)
+#elif 1
+template <class Dest, class Source>
+inline Dest bit_cast(Source const& source) {
+    static_assert(sizeof(Dest) == sizeof(Source), "size of destination and source objects must be equal");
+    static_assert(std::is_trivially_copyable<Dest>::value, "destination type must be trivially copyable.");
+    static_assert(std::is_trivially_copyable<Source>::value, "source type must be trivially copyable");
+
+    Dest dest;
+    std::memcpy(&dest, &source, sizeof(dest));
+    return dest;
+}
+#define float_as_int(x) bit_cast<int,float>(x)
+#define int_as_float(x) bit_cast<float,int>(x)
+#define uint_as_float(x) bit_cast<float,unsigned int>(x)
+#else
+inline int float_as_int(const float x)
+{
+   union {
+      float f;
+      int i;
+   } uc;
+   uc.f = x;
+   return uc.i;
+}
+
+inline float int_as_float(const int i)
+{
+   union {
+      int i;
+      float f;
+   } iaf;
+   iaf.i = i;
+   return iaf.f;
+}
+
+inline float uint_as_float(const unsigned int i)
+{
+   union {
+      unsigned int u;
+      float f;
+   } iaf;
+   iaf.u = i;
+   return iaf.f;
+}
+#endif
+
 namespace Util
 {
   namespace detail

--- a/Src/Util/GenericValue.h
+++ b/Src/Util/GenericValue.h
@@ -20,57 +20,6 @@
 #include <memory>
 #include <cctype>
 
-#if __cplusplus >= 202002L
-#include <bit>
-#define float_as_int(x) std::bit_cast<int>(x)
-#define int_as_float(x) std::bit_cast<float>(x)
-#define uint_as_float(x) std::bit_cast<float>(x)
-#elif 1
-template <class Dest, class Source>
-inline Dest bit_cast(Source const& source) {
-    static_assert(sizeof(Dest) == sizeof(Source), "size of destination and source objects must be equal");
-    static_assert(std::is_trivially_copyable<Dest>::value, "destination type must be trivially copyable.");
-    static_assert(std::is_trivially_copyable<Source>::value, "source type must be trivially copyable");
-
-    Dest dest;
-    std::memcpy(&dest, &source, sizeof(dest));
-    return dest;
-}
-#define float_as_int(x) bit_cast<int,float>(x)
-#define int_as_float(x) bit_cast<float,int>(x)
-#define uint_as_float(x) bit_cast<float,unsigned int>(x)
-#else
-inline int float_as_int(const float x)
-{
-   union {
-      float f;
-      int i;
-   } uc;
-   uc.f = x;
-   return uc.i;
-}
-
-inline float int_as_float(const int i)
-{
-   union {
-      int i;
-      float f;
-   } iaf;
-   iaf.i = i;
-   return iaf.f;
-}
-
-inline float uint_as_float(const unsigned int i)
-{
-   union {
-      unsigned int u;
-      float f;
-   } iaf;
-   iaf.u = i;
-   return iaf.f;
-}
-#endif
-
 namespace Util
 {
   namespace detail

--- a/VS2008/Supermodel.vcxproj
+++ b/VS2008/Supermodel.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -545,6 +545,7 @@ xcopy /D /Y "$(ProjectDir)..\Config\*" "$(TargetDir)Config"</Command>
     <ClInclude Include="..\Src\Sound\SCSP.h" />
     <ClInclude Include="..\Src\Sound\SCSPDSP.h" />
     <ClInclude Include="..\Src\Supermodel.h" />
+    <ClInclude Include="..\Src\Util\BitCast.h" />
     <ClInclude Include="..\Src\Util\BitRegister.h" />
     <ClInclude Include="..\Src\Util\BMPFile.h" />
     <ClInclude Include="..\Src\Util\ByteSwap.h" />

--- a/VS2008/Supermodel.vcxproj.filters
+++ b/VS2008/Supermodel.vcxproj.filters
@@ -847,6 +847,9 @@
     <ClInclude Include="..\Src\Graphics\New3D\Vec.h">
       <Filter>Header Files\Graphics\New</Filter>
     </ClInclude>
+    <ClInclude Include="..\Src\Util\BitCast.h">
+      <Filter>Header Files\Util</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\Src\Debugger\ReadMe.txt">


### PR DESCRIPTION
Harmless math warning fixes/optimizations, no functional change (apart from being faster as no double<->float casts).
Change map->unordered_map in CNew3D::CacheModel (as no order needed there).
Avoid general pointer aliasing problems (using bit_cast (C++20 if available), or the recommended/compiler-optimized-away memcpy) to be more future proof.