### PR TITLE
Reinstate a Star Wars hack

### DIFF
--- a/Src/Graphics/New3D/New3D.cpp
+++ b/Src/Graphics/New3D/New3D.cpp
@@ -1670,7 +1670,12 @@ void CNew3D::SetSunClamp(bool enable)
 
 void CNew3D::SetSignedShade(bool enable)
 {
-	m_shadeIsSigned = enable;
+	if (m_gameName == "swtrilgy" || m_gameName == "swtrilgya") {
+		m_shadeIsSigned = false;
+	}
+	else {
+		m_shadeIsSigned = enable;
+	}
 }
 
 float CNew3D::GetLosValue(int layer)


### PR DESCRIPTION
Restores missing textures in the tunnel run near the end of the game.
As per the old hack, it would need to be removed if JTAG was ever emulated.