### PR TITLE
Fix new 3D engine texture2DLod function missing error on Linux/MESA.

### DIFF
--- a/Src/Graphics/New3D/R3DShaderTriangles.h
+++ b/Src/Graphics/New3D/R3DShaderTriangles.h
@@ -62,6 +62,7 @@ void main(void)
 static const char *fragmentShaderR3D = R"glsl(
 
 #version 120
+#extension GL_ARB_shader_texture_lod : require
 
 uniform sampler2D tex1;			// base tex
 uniform sampler2D tex2;			// micro tex (optional)


### PR DESCRIPTION
MESA requires needed extensions to be explicitly declared in code otherwise it will not enable them.
Solves: https://github.com/trzy/Supermodel/issues/4