### PR TITLE
Games.xml: magtruck (partially) redumped

### DIFF
--- a/Config/Games.xml
+++ b/Config/Games.xml
@@ -1237,15 +1237,13 @@
     </hardware>
     <roms>
       <patches>
-	    <!-- Fixing bad ROM dump which causes attract mode to stop rendering -->
-        <patch region="crom" bits="32" offset="0x091A34" value="0x917F0068" />
         <!-- Enable Region change (remove the patch to return to Japan region) -->
         <patch region="crom" bits="32" offset="0x14B25C" value="0x38600001" />
       </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
-        <file offset="0" name="epr-21434.20" crc32="0xE028D7CA" />
+        <file offset="0" name="epr-21434.20" crc32="0x18F8626A" />
         <file offset="2" name="epr-21436.19" crc32="0x22BCBCA3" />
-        <file offset="4" name="epr-21433.18" crc32="0x60AA9D76" />
+        <file offset="4" name="epr-21433.18" crc32="0xB3B124FA" />
         <file offset="6" name="epr-21435.17" crc32="0x9B169446" />
       </region>
       <region name="banked_crom" stride="8" chunk_size="2" byte_swap="true">


### PR DESCRIPTION
Bad dump patch no longer needed. Region change patch still works.

MAME commit,
https://github.com/mamedev/mame/commit/b24695eda73a7206a75f432eddbd88508e8c62d4

Only 2 ROMS have actually changed. MAME have oddly changed the version to 'Export', which seems wrong, as it defaults to Japan without the region enable patch.