### PR TITLE
Add uint declaration to line 1903 of m68kcpu.h

### DIFF
--- a/Src/CPU/68K/Musashi/m68kcpu.h
+++ b/Src/CPU/68K/Musashi/m68kcpu.h
@@ -1899,7 +1899,10 @@ static inline void m68ki_exception_interrupt(uint int_level)
 		return;
 
 	/* Acknowledge the interrupt */
-	vector = m68ki_int_ack(int_level);
+#if defined(__APPLE__)
+    uint m68ki_int_ack(uint);
+#endif
+    vector = m68ki_int_ack(int_level);
 
 	/* Get the interrupt vector */
 	if(vector == M68K_INT_ACK_AUTOVECTOR)


### PR DESCRIPTION
Fix long-standing compiler error on macOS.

Submitting per my comments in "Supermodel macOS Binaries for latest SVN release..." forum thread...