### PR TITLE
change all INT16 mixing/intermediate clamping to floats

### DIFF
--- a/Src/Inputs/Input.cpp
+++ b/Src/Inputs/Input.cpp
@@ -91,7 +91,7 @@ const char* CInput::GetInputGroup()
 		case Game::INPUT_JOYSTICK1:       // Fall through to below
 		case Game::INPUT_JOYSTICK2:       return "4-Way Joysticks";
 		case Game::INPUT_FIGHTING:        return "Fighting Game Buttons";
-		case Game::INPUT_SPIKEOUT:		 return "Spikeout Buttons";
+		case Game::INPUT_SPIKEOUT:        return "Spikeout Buttons";
 		case Game::INPUT_SOCCER:          return "Virtua Striker Buttons";
 		case Game::INPUT_VEHICLE:         return "Racing Game Steering Controls";
 		case Game::INPUT_SHIFT4:          return "Racing Game Gear 4-Way Shift";
@@ -108,8 +108,8 @@ const char* CInput::GetInputGroup()
 		case Game::INPUT_ANALOG_GUN2:     return "Analog Guns";
 		case Game::INPUT_SKI:             return "Ski Controls";
 		case Game::INPUT_MAGTRUCK:        return "Magical Truck Controls";
-	  case Game::INPUT_FISHING:         return "Fishing Controls";
-		default:                         return "Misc";
+		case Game::INPUT_FISHING:         return "Fishing Controls";
+		default:                          return "Misc";
 	}
 }
 
@@ -138,7 +138,7 @@ void CInput::AppendMapping(const char *mapping)
 	else
 	{
 		// Otherwise, append to mapping string and recreate source from new mapping string
-		int size = MAX_MAPPING_LENGTH - strlen(m_mapping);
+		size_t size = MAX_MAPPING_LENGTH - strlen(m_mapping);
 		strncat(m_mapping, ",", size--);
 		strncat(m_mapping, mapping, size);
 		CreateSource();

--- a/Src/Model3/DSB.h
+++ b/Src/Model3/DSB.h
@@ -71,7 +71,7 @@
 class CDSBResampler
 {
 public:
-	int		UpSampleAndMix(INT16 *outL, INT16 *outR, INT16 *inL, INT16 *inR, UINT8 volumeL, UINT8 volumeR, int sizeOut, int sizeIn, int outRate, int inRate);
+	int		UpSampleAndMix(float *outL, float *outR, INT16 *inL, INT16 *inR, UINT8 volumeL, UINT8 volumeR, int sizeOut, int sizeIn, int outRate, int inRate);
 	void	Reset(void);
 	CDSBResampler(const Util::Config::Node &config)
 	  : m_config(config)
@@ -114,7 +114,7 @@ public:
 	 *		audioL	Left audio channel, one frame (44 KHz, 1/60th second).
 	 *		audioR	Right audio channel.
 	 */
-	virtual void RunFrame(INT16 *audioL, INT16 *audioR) = 0;
+	virtual void RunFrame(float *audioL, float *audioR) = 0;
 
 	/*
 	 * Reset(void):
@@ -187,7 +187,7 @@ public:
 
 	// DSB interface (see CDSB definition)
 	void 	SendCommand(UINT8 data);
-	void 	RunFrame(INT16 *audioL, INT16 *audioR);
+	void 	RunFrame(float *audioL, float *audioR);
 	void 	Reset(void);
 	void	SaveState(CBlockFile *StateFile);
 	void	LoadState(CBlockFile *StateFile);
@@ -264,7 +264,7 @@ public:
 
 	// DSB interface (see definition of CDSB)
 	void 	SendCommand(UINT8 data);
-	void 	RunFrame(INT16 *audioL, INT16 *audioR);
+	void 	RunFrame(float *audioL, float *audioR);
 	void 	Reset(void);
 	void	SaveState(CBlockFile *StateFile);
 	void	LoadState(CBlockFile *StateFile);

--- a/Src/Model3/SoundBoard.h
+++ b/Src/Model3/SoundBoard.h
@@ -203,8 +203,8 @@ private:
 	UINT8	ctrlReg;			// control register: ROM banking
 	
 	// Audio
-	INT16* audioFL, * audioFR;	// left and right front audio channels (1/60th second, 44.1 KHz)
-	INT16* audioRL, * audioRR;	// left and right rear audio channels (1/60th second, 44.1 KHz)
+	float* audioFL, * audioFR;	// left and right front audio channels (1/60th second, 44.1 KHz)
+	float* audioRL, * audioRR;	// left and right rear audio channels (1/60th second, 44.1 KHz)
 };
 
 

--- a/Src/OSD/Audio.h
+++ b/Src/OSD/Audio.h
@@ -51,7 +51,7 @@ extern bool OpenAudio(const Util::Config::Node& config);
  *
  * Sends a chunk of two-channel audio with the given number of samples to the audio system.
  */
-extern bool OutputAudio(unsigned numSamples, INT16* leftFrontBuffer, INT16* rightFrontBuffer, INT16* leftRearBuffer, INT16* rightRearBuffer, bool flipStereo);
+extern bool OutputAudio(unsigned numSamples, const float* leftFrontBuffer, const float* rightFrontBuffer, const float* leftRearBuffer, const float* rightRearBuffer, bool flipStereo);
 
 /*
  * CloseAudio()

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -117,7 +117,7 @@ static bool SetGLGeometry(unsigned *xOffsetPtr, unsigned *yOffsetPtr, unsigned *
   float yRes = float(*yResPtr);
   if (keepAspectRatio)
   {
-    float model3Ratio = 496.0f/384.0f;
+    float model3Ratio = 496.0/384.0;
     if (yRes < (xRes/model3Ratio))
       xRes = yRes*model3Ratio;
     if (xRes < (yRes*model3Ratio))
@@ -153,7 +153,7 @@ static bool SetGLGeometry(unsigned *xOffsetPtr, unsigned *yOffsetPtr, unsigned *
   *xResPtr = (unsigned) xRes;
   *yResPtr = (unsigned) yRes;
 
-  UINT32 correction = (UINT32)(((yRes / 384.f) * 2) + 0.5f);
+  UINT32 correction = (UINT32)(((yRes / 384.f) * 2.f) + 0.5f);
 
   glEnable(GL_SCISSOR_TEST);
 
@@ -1384,7 +1384,7 @@ static void PrintGameList(const std::string &xml_file, const std::map<std::strin
   {
     const Game &game = v.second;
     printf("    %s", game.name.c_str());
-    for (int i = game.name.length(); i < 9; i++)  // pad for alignment (no game ID should be more than 9 letters)
+    for (size_t i = game.name.length(); i < 9; i++)  // pad for alignment (no game ID should be more than 9 letters)
       printf(" ");
     if (!game.version.empty())
       printf("       %s (%s)\n", game.title.c_str(), game.version.c_str());
@@ -1425,9 +1425,9 @@ static Util::Config::Node DefaultConfig()
   config.Set("FragmentShader2D", "");
   // CSoundBoard
   config.Set("EmulateSound", true);
-  config.Set("Balance", "0");
-  config.Set("BalanceLeftRight", "0");
-  config.Set("BalanceFrontRear", "0");
+  config.Set("Balance", "0.0");
+  config.Set("BalanceLeftRight", "0.0");
+  config.Set("BalanceFrontRear", "0.0");
   config.Set("NbSoundChannels", "4");
   config.Set("SoundFreq", "57.6"); // 60.0f? 57.524160f?
   // CDSB

--- a/Src/Sound/SCSP.h
+++ b/Src/Sound/SCSP.h
@@ -83,7 +83,7 @@ UINT32 SCSP_Slave_r32(UINT32 addr);
 // Supermodel interface functions
 void SCSP_SaveState(CBlockFile *StateFile);
 void SCSP_LoadState(CBlockFile *StateFile);
-void SCSP_SetBuffers(INT16 *leftBufferPtr, INT16 *rightBufferPtr, INT16* leftRearBufferPtr, INT16* rightRearBufferPtr, int bufferLength);
+void SCSP_SetBuffers(float *leftBufferPtr, float *rightBufferPtr, float* leftRearBufferPtr, float* rightRearBufferPtr, int bufferLength);
 void SCSP_Deinit(void);
 
 


### PR DESCRIPTION
also fixes 3 bugs:
1) mpeg right channel volume attenuation was always using the left channel volume instead
2) too high MusicVolume setting was not clamped to 0..200
3) too high SoundVolume setting was not clamped to 0..200

partially addresses issue #22 