### PR TITLE
Add automatic detection for Brew-installed SDL2 and SDL_net

### DIFF
--- a/Makefiles/Makefile.OSX
+++ b/Makefiles/Makefile.OSX
@@ -60,7 +60,7 @@ BREW_IS_INSTALLED = $(shell which brew >> /dev/null 2>&1 && echo 1 || echo 0)
 ifeq ($(BREW_IS_INSTALLED),1)
 	BREW_SDL = $(shell brew list | grep ^sdl2$$ | wc -l | xargs)
 	ifeq ($(BREW_SDL),1)
-		BREW_SDLNET = $(shell brew list | grep ^sdl_net$$ | wc -l | xargs)
+		BREW_SDLNET = $(shell brew list | grep ^sdl2_net$$ | wc -l | xargs)
 		ifeq ($(BREW_SDLNET),1)
 			USE_BREW = 1
 		endif

--- a/Makefiles/Makefile.OSX
+++ b/Makefiles/Makefile.OSX
@@ -55,14 +55,14 @@ LD = clang
 # Brew Tests
 #
 
-USE_BREW = 0
-BREW_IS_INSTALLED = $(shell which brew >> /dev/null 2>&1 && echo 1 || echo 0)
-ifeq ($(BREW_IS_INSTALLED),1)
-	BREW_SDL = $(shell brew list | grep ^sdl2$$ | wc -l | xargs)
-	ifeq ($(BREW_SDL),1)
-		BREW_SDLNET = $(shell brew list | grep ^sdl2_net$$ | wc -l | xargs)
-		ifeq ($(BREW_SDLNET),1)
-			USE_BREW = 1
+BREWED_SUPERMODEL = 0
+BREW_IS_INSTALLED_SM = $(shell which brew >> /dev/null 2>&1 && echo 1 || echo 0)
+ifeq ($(BREW_IS_INSTALLED_SM),1)
+	BREW_SDL2_SM = $(shell brew list | grep ^sdl2$$ | wc -l | xargs)
+	ifeq ($(BREW_SDL2_SM),1)
+		BREW_SDL2NET_SM = $(shell brew list | grep ^sdl2_net$$ | wc -l | xargs)
+		ifeq ($(BREW_SDL2NET_SM),1)
+			BREWED_SUPERMODEL = 1
 		endif
 	endif
 endif
@@ -71,7 +71,7 @@ endif
 # SDL
 #
 
-ifeq ($(strip $(USE_BREW)),1)
+ifeq ($(strip $(BREWED_SUPERMODEL)),1)
 	SDL_CFLAGS = -I$(shell brew --prefix)/include
 	SDL_LIBS = -L$(shell brew --prefix)/lib -lSDL2
 	ifeq ($(strip $(NET_BOARD)),1)

--- a/Makefiles/Makefile.OSX
+++ b/Makefiles/Makefile.OSX
@@ -55,14 +55,15 @@ LD = clang
 # Brew Tests
 #
 
-BREWED_SUPERMODEL = 0
-BREW_IS_INSTALLED_SM = $(shell which brew >> /dev/null 2>&1 && echo 1 || echo 0)
-ifeq ($(BREW_IS_INSTALLED_SM),1)
-	BREW_SDL2_SM = $(shell brew list | grep ^sdl2$$ | wc -l | xargs)
-	ifeq ($(BREW_SDL2_SM),1)
-		BREW_SDL2NET_SM = $(shell brew list | grep ^sdl2_net$$ | wc -l | xargs)
-		ifeq ($(BREW_SDL2NET_SM),1)
-			BREWED_SUPERMODEL = 1
+ifeq ($(strip $(BREWED_SUPERMODEL)),)
+	BREW_IS_INSTALLED_SM = $(shell which brew >> /dev/null 2>&1 && echo 1 || echo 0)
+	ifeq ($(BREW_IS_INSTALLED_SM),1)
+		BREW_SDL2_SM = $(shell brew list | grep ^sdl2$$ | wc -l | xargs)
+		ifeq ($(BREW_SDL2_SM),1)
+			BREW_SDL2NET_SM = $(shell brew list | grep ^sdl2_net$$ | wc -l | xargs)
+			ifeq ($(BREW_SDL2NET_SM),1)
+				BREWED_SUPERMODEL = 1
+			endif
 		endif
 	endif
 endif

--- a/Makefiles/Makefile.OSX
+++ b/Makefiles/Makefile.OSX
@@ -52,14 +52,40 @@ CXX = clang
 LD = clang
 
 #
+# Brew Tests
+#
+
+USE_BREW = 0
+BREW_IS_INSTALLED = $(shell which brew >> /dev/null 2>&1 && echo 1 || echo 0)
+ifeq ($(BREW_IS_INSTALLED),1)
+	BREW_SDL = $(shell brew list | grep ^sdl2$$ | wc -l | xargs)
+	ifeq ($(BREW_SDL),1)
+		BREW_SDLNET = $(shell brew list | grep ^sdl_net$$ | wc -l | xargs)
+		ifeq ($(BREW_SDLNET),1)
+			USE_BREW = 1
+		endif
+	endif
+endif
+
+#
 # SDL
 #
 
-SDL_CFLAGS =
-SDL_LIBS = -framework SDL2 -framework AGL -framework OpenGL -framework GLUT -framework Cocoa
-ifeq ($(strip $(NET_BOARD)),1)
-	SDL_LIBS += -framework SDL2_net
+ifeq ($(strip $(USE_BREW)),1)
+	SDL_CFLAGS = -I$(shell brew --prefix)/include
+	SDL_LIBS = -L$(shell brew --prefix)/lib -lSDL2
+	ifeq ($(strip $(NET_BOARD)),1)
+		SDL_LIBS += -lSDL2_net
+	endif
+else
+	SDL_LIBS = -framework SDL2
+	ifeq ($(strip $(NET_BOARD)),1)
+		SDL_LIBS += -framework SDL2_net
+	endif
 endif
+
+SDL_CFLAGS +=
+SDL_LIBS += -framework AGL -framework OpenGL -framework GLUT -framework Cocoa
 
 #
 #	OSX-specific

--- a/Makefiles/Rules.inc
+++ b/Makefiles/Rules.inc
@@ -65,9 +65,9 @@ ifeq ($(strip $(ENABLE_DEBUGGER)),1)
 	SUPERMODEL_BUILD_FLAGS += -DSUPERMODEL_DEBUGGER
 endif
 
-# If using Brew version of SDL, need to define USE_BREW
-ifeq ($(strip $(USE_BREW)),1)
-	SUPERMODEL_BUILD_FLAGS += -DUSE_BREW
+# If using Brew version of SDL, need to define BREWED_SUPERMODEL
+ifeq ($(strip $(BREWED_SUPERMODEL)),1)
+	SUPERMODEL_BUILD_FLAGS += -DBREWED_SUPERMODEL
 endif
 
 #

--- a/Makefiles/Rules.inc
+++ b/Makefiles/Rules.inc
@@ -65,6 +65,11 @@ ifeq ($(strip $(ENABLE_DEBUGGER)),1)
 	SUPERMODEL_BUILD_FLAGS += -DSUPERMODEL_DEBUGGER
 endif
 
+# If using Brew version of SDL, need to define USE_BREW
+ifeq ($(strip $(USE_BREW)),1)
+	SUPERMODEL_BUILD_FLAGS += -DUSE_BREW
+endif
+
 #
 # Compiler options
 #

--- a/Src/OSD/SDL/SDLIncludes.h
+++ b/Src/OSD/SDL/SDLIncludes.h
@@ -39,7 +39,7 @@
 
 #ifdef NET_BOARD
 #ifdef SUPERMODEL_OSX
-#ifdef USE_BREW
+#ifdef BREWED_SUPERMODEL
 #include <SDL2/SDL_net.h>
 #else
 #include <SDL2_net/SDL_net.h>

--- a/Src/OSD/SDL/SDLIncludes.h
+++ b/Src/OSD/SDL/SDLIncludes.h
@@ -42,7 +42,7 @@
 #ifdef USE_BREW
 #include <SDL2/SDL_net.h>
 #else
-#include <SDL2_net/SDL2_net.h>
+#include <SDL2_net/SDL_net.h>
 #endif
 #else
 #include <SDL_net.h>

--- a/Src/OSD/SDL/SDLIncludes.h
+++ b/Src/OSD/SDL/SDLIncludes.h
@@ -39,7 +39,11 @@
 
 #ifdef NET_BOARD
 #ifdef SUPERMODEL_OSX
+#ifdef USE_BREW
+#include <SDL2/SDL_net.h>
+#else
 #include <SDL2_net/SDL_net.h>
+#endif
 #else
 #include <SDL_net.h>
 #endif

--- a/Src/OSD/SDL/SDLIncludes.h
+++ b/Src/OSD/SDL/SDLIncludes.h
@@ -42,7 +42,7 @@
 #ifdef USE_BREW
 #include <SDL2/SDL_net.h>
 #else
-#include <SDL2_net/SDL_net.h>
+#include <SDL2_net/SDL2_net.h>
 #endif
 #else
 #include <SDL_net.h>


### PR DESCRIPTION
Here is a PR regarding my compiling problem on Mac, namely detecting and using Brew-installed SDL2 and SDL_net libraries instead of manually installing them.

refers to : [issue#38](https://github.com/trzy/Supermodel/issues/38)