### PR TITLE
add undefd codepath for correct use of the 18bit DAC path (which seem…

### DIFF
--- a/Src/OSD/SDL/Audio.cpp
+++ b/Src/OSD/SDL/Audio.cpp
@@ -142,30 +142,6 @@ void SetAudioType(Game::AudioTypes type)
     AudioType = type;
 }
 
-static INT16 AddAndClampINT16(INT32 x, INT32 y)
-{
-    INT32 sum = x + y;
-    if (sum > INT16_MAX) {
-        sum = INT16_MAX;
-    }
-    if (sum < INT16_MIN) {
-        sum = INT16_MIN;
-    }
-    return (INT16)sum;
-}
-
-static INT16 MixINT16(INT32 x, INT32 y)
-{
-    INT32 sum = (x + y)>>1;
-    if (sum > INT16_MAX) {
-        sum = INT16_MAX;
-    }
-    if (sum < INT16_MIN) {
-        sum = INT16_MIN;
-    }
-    return (INT16)sum;
-}
-
 static INT16 MixINT16(float x, float y)
 {
     INT32 sum = (INT32)((x + y)*0.5f); //!! dither
@@ -185,7 +161,7 @@ static float MixFloat(float x, float y)
 
 static INT16 ClampINT16(float x)
 {
-    INT32 xi = (INT32)x;
+    INT32 xi = (INT32)x; //!! dither
     if (xi > INT16_MAX) {
         xi = INT16_MAX;
     }

--- a/Src/Sound/MPEG/MpegAudio.cpp
+++ b/Src/Sound/MPEG/MpegAudio.cpp
@@ -132,5 +132,3 @@ void MpegDec::DecodeAudio(int16_t* left, int16_t* right, int numStereoSamples)
 	}
 
 }
-
-

--- a/Src/Sound/SCSPDSP.cpp
+++ b/Src/Sound/SCSPDSP.cpp
@@ -150,13 +150,10 @@ unsigned char UnpackFunc[]={0x8B,0xD8,0x8B,0xC8,0x81,0xE3,0x00,0x80,0x00,0x00,0x
 
 static UINT16 PACK(INT32 val)
 {
-	UINT32 temp;
-	int sign, exponent, k;
-
-	sign = (val >> 23) & 0x1;
-	temp = (val ^ (val << 1)) & 0xFFFFFF;
-	exponent = 0;
-	for (k = 0; k < 12; k++)
+	int sign = (val >> 23) & 0x1;
+	UINT32 temp = (val ^ (val << 1)) & 0xFFFFFF;
+	int exponent = 0;
+	for (int k = 0; k < 12; k++)
 	{
 		if (temp & 0x800000)
 			break;
@@ -177,13 +174,10 @@ static UINT16 PACK(INT32 val)
 
 static INT32 UNPACK(UINT16 val)
 {
-	int sign, exponent, mantissa;
-	INT32 uval;
-
-	sign = (val >> 15) & 0x1;
-	exponent = (val >> 11) & 0xF;
-	mantissa = val & 0x7FF;
-	uval = mantissa << 11;
+	int sign = (val >> 15) & 0x1;
+	int exponent = (val >> 11) & 0xF;
+	int mantissa = val & 0x7FF;
+	INT32 uval = mantissa << 11;
 	if (exponent > 11)
 	{
 		exponent = 11;
@@ -417,7 +411,7 @@ void SCSPDSP_Step(_SCSPDSP *DSP)
 			//ADDR+=DSP->RBP<<13;
 			//MEMVAL=DSP->SCSPRAM[ADDR>>1];
 			ADDR += DSP->RBP << 12;
-			if (ADDR > 0x7ffff) ADDR = 0;
+			if (ADDR > 0x7ffff) ADDR = 0; //!! MAME has ADDR <<= 1 in here, but this seems to be wrong?
 			if (MRD && (step & 1)) //memory only allowed on odd? DoA inserts NOPs on even
 			{
 				if (NOFL)

--- a/Src/Sound/SCSPLFO.cpp
+++ b/Src/Sound/SCSPLFO.cpp
@@ -49,10 +49,13 @@ struct _LFO
 
 static int PLFO_TRI[256], PLFO_SQR[256], PLFO_SAW[256], PLFO_NOI[256];
 static int ALFO_TRI[256], ALFO_SQR[256], ALFO_SAW[256], ALFO_NOI[256];
-static float LFOFreq[32] = { 0.17f, 0.19f, 0.23f, 0.27f, 0.34f, 0.39f, 0.45f, 0.55f, 0.68f, 0.78f, 0.92f, 1.10f, 1.39f, 1.60f, 1.87f, 2.27f,
-			  2.87f, 3.31f, 3.92f, 4.79f, 6.15f, 7.18f, 8.60f, 10.8f, 14.4f, 17.2f, 21.5f, 28.7f, 43.1f, 57.4f, 86.1f, 172.3f };
-static float ASCALE[8] = { 0.0f, 0.4f, 0.8f, 1.5f, 3.0f, 6.0f, 12.0f, 24.0f };
-static float PSCALE[8] = { 0.0f, 7.0f, 13.5f, 27.0f, 55.0f, 112.0f, 230.0f, 494.0f };
+static const float LFOFreq[32] =
+{
+	0.17f,0.19f,0.23f,0.27f,0.34f,0.39f,0.45f,0.55f,0.68f,0.78f,0.92f,1.10f,1.39f,1.60f,1.87f,2.27f,
+	2.87f,3.31f,3.92f,4.79f,6.15f,7.18f,8.60f,10.8f,14.4f,17.2f,21.5f,28.7f,43.1f,57.4f,86.1f,172.3f
+};
+static const float ASCALE[8] = {0.0f,0.4f,0.8f,1.5f,3.0f,6.0f,12.0f,24.0f};
+static const float PSCALE[8] = {0.0f,7.0f,13.5f,27.0f,55.0f,112.0f,230.0f,494.0f};
 static int PSCALES[8][256];
 static int ASCALES[8][256];
 
@@ -141,9 +144,9 @@ signed int inline ALFO_Step(struct _LFO *LFO)
 {
 	int p;
 	LFO->phase += LFO->phase_step;
-#if LFO_SHIFT!=8    
+#if LFO_SHIFT!=8
 	LFO->phase &= (1 << (LFO_SHIFT + 8)) - 1;
-#endif    
+#endif
 	p = LFO->table[LFO->phase >> LFO_SHIFT];
 	p = LFO->scale[p];
 	return p << (SHIFT - LFO_SHIFT);
@@ -151,7 +154,7 @@ signed int inline ALFO_Step(struct _LFO *LFO)
 
 void LFO_ComputeStep(struct _LFO *LFO, UINT32 LFOF, UINT32 LFOWS, UINT32 LFOS, int ALFO)
 {
-	float step = (float)LFOFreq[LFOF] * 256.0f / (float)44100.0f;
+	float step = (float)LFOFreq[LFOF] * 256.0f / 44100.0f;
 	LFO->phase_step = (unsigned int)((float)(1 << LFO_SHIFT)*step);
 	if (ALFO)
 	{


### PR DESCRIPTION
…s to be triggered for all games)

the volume correction to bring the data back into a valid range is not really needed in practice though, only Daytona2 seems to need it, and also only extremely rarely, so lets just live with a tiny bit of clamping for that game then

while at it, make some formatting similar to MAME, and add one comment regarding a most likely wrong recent MAME change