### PR TITLE
[Makefile.Win32] $MSYSTEM check never fails.

### DIFF
--- a/Makefiles/Makefile.Win32
+++ b/Makefiles/Makefile.Win32
@@ -73,7 +73,7 @@ endif
 # Use Bash or Windows Prompt shell commands?
 #
 DELETE = rm -d -r -f
-ifeq ($(strip $(MSYSTEM)),)
+ifeq ($(strip $(MSYSTEM)),1)
 	DELETE = rmdir /s /q
 endif
 


### PR DESCRIPTION
'make clean' from Win command shell doesn't fully clean, condition always true.