### PR TITLE
Incomplete texture headers uploaded via FIFO are now discarded

### DIFF
--- a/Src/Model3/Real3D.cpp
+++ b/Src/Model3/Real3D.cpp
@@ -656,9 +656,9 @@ void CReal3D::Flush(void)
   DebugLog("Real3D 88000000 written @ PC=%08X\n", ppc_get_pc());
 
   // Upload textures (if any)
-  if (fifoIdx > 0)
+  if (fifoIdx > 2) // If the texture header/data aren't present, discard the texture (prevents garbage textures in Ski Champ)
   {
-    for (uint32_t i = 0; i < fifoIdx; )
+    for (uint32_t i = 0; i < fifoIdx - 2; )
     {
       uint32_t size = 2+textureFIFO[i+0]/2;
       size /= 4;


### PR DESCRIPTION
Ski Champ sends one more 32-bit word via DMA than it should which was causing Supermodel to erroneously interpret the extra word as another texture