### PR TITLE
Add FileSystemPath.cpp to Visual Studio project

### DIFF
--- a/VS2008/Supermodel.vcxproj
+++ b/VS2008/Supermodel.vcxproj
@@ -351,6 +351,7 @@ xcopy /D /Y "$(ProjectDir)..\Config\*" "$(TargetDir)Config"</Command>
     <ClCompile Include="..\Src\OSD\SDL\SDLInputSystem.cpp" />
     <ClCompile Include="..\Src\OSD\SDL\Thread.cpp" />
     <ClCompile Include="..\Src\OSD\Windows\DirectInputSystem.cpp" />
+    <ClCompile Include="..\Src\OSD\Windows\FileSystemPath.cpp" />
     <ClCompile Include="..\Src\OSD\Windows\WinOutputs.cpp" />
     <ClCompile Include="..\Src\Pkgs\glew.c">
       <ExceptionHandling Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/VS2008/Supermodel.vcxproj.filters
+++ b/VS2008/Supermodel.vcxproj.filters
@@ -257,6 +257,9 @@
     <ClCompile Include="..\Src\OSD\Windows\WinOutputs.cpp">
       <Filter>Source Files\OSD\Windows</Filter>
     </ClCompile>
+    <ClCompile Include="..\Src\OSD\Windows\FileSystemPath.cpp">
+      <Filter>Source Files\OSD\Windows</Filter>
+    </ClCompile>
     <ClCompile Include="..\Src\Pkgs\glew.c">
       <Filter>Source Files\Pkgs</Filter>
     </ClCompile>


### PR DESCRIPTION
Fixes "unresolved external symbol" error when building with Visual Studio