### PR TITLE
Add multiple independent mice support for Linux

### DIFF
--- a/Makefiles/Makefile.UNIX
+++ b/Makefiles/Makefile.UNIX
@@ -63,7 +63,7 @@ SDL2_LIBS = `sdl2-config --libs`
 #
 
 PLATFORM_CXXFLAGS = $(SDL2_CFLAGS) -O3
-PLATFORM_LDFLAGS = $(SDL2_LIBS) -lGL -lGLU -lz -lm -lstdc++ -lpthread -lSDL2_net
+PLATFORM_LDFLAGS = $(SDL2_LIBS) -lGL -lGLU -lz -lm -lstdc++ -lpthread -lSDL2_net -ldl
 
 
 ###############################################################################

--- a/Makefiles/Rules.inc
+++ b/Makefiles/Rules.inc
@@ -147,6 +147,9 @@ SRC_FILES = \
 	Src/Inputs/InputSource.cpp \
 	Src/Inputs/InputSystem.cpp \
 	Src/Inputs/InputTypes.cpp \
+	Src/Inputs/Linux_evdev.c \
+	Src/Inputs/X11_xinput2.c \
+	Src/Inputs/Manymouse.c \
 	Src/Inputs/MultiInputSource.cpp \
 	Src/OSD/SDL/SDLInputSystem.cpp \
 	Src/OSD/Outputs.cpp \

--- a/Src/Inputs/Linux_evdev.c
+++ b/Src/Inputs/Linux_evdev.c
@@ -1,0 +1,336 @@
+/*
+ * Support for Linux evdevs...the /dev/input/event* devices.
+ *
+ * Please see the file LICENSE.txt in the source's root directory.
+ *
+ *  This file written by Ryan C. Gordon.
+ */
+
+#include "Manymouse.h"
+
+#ifdef __linux__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <linux/input.h>  /* evdev interface...  */
+
+#define test_bit(array, bit)    (array[bit/8] & (1<<(bit%8)))
+
+/* linux allows 32 evdev nodes currently. */
+#define MAX_MICE 32
+typedef struct
+{
+    int fd;
+    int min_x;
+    int min_y;
+    int max_x;
+    int max_y;
+    char name[64];
+} MouseStruct;
+
+static MouseStruct mice[MAX_MICE];
+static unsigned int available_mice = 0;
+
+
+static int poll_mouse(MouseStruct *mouse, ManyMouseEvent *outevent)
+{
+    int unhandled = 1;
+    while (unhandled)  /* read until failure or valid event. */
+    {
+        struct input_event event;
+        int br = (int)read(mouse->fd, &event, sizeof (event));
+        if (br == -1)
+        {
+            if (errno == EAGAIN)
+                return 0;  /* just no new data at the moment. */
+
+            /* mouse was unplugged? */
+            close(mouse->fd);  /* stop reading from this mouse. */
+            mouse->fd = -1;
+            outevent->type = MANYMOUSE_EVENT_DISCONNECT;
+            return 1;
+        } /* if */
+
+        if (br != sizeof (event))
+            return 0;  /* oh well. */
+
+        unhandled = 0;  /* will reset if necessary. */
+        outevent->value = event.value;
+        if (event.type == EV_REL)
+        {
+            outevent->type = MANYMOUSE_EVENT_RELMOTION;
+            if ((event.code == REL_X) || (event.code == REL_DIAL))
+                outevent->item = 0;
+            else if (event.code == REL_Y)
+                outevent->item = 1;
+
+            else if (event.code == REL_WHEEL)
+            {
+                outevent->type = MANYMOUSE_EVENT_SCROLL;
+                outevent->item = 0;
+            } /* else if */
+
+            else if (event.code == REL_HWHEEL)
+            {
+                outevent->type = MANYMOUSE_EVENT_SCROLL;
+                outevent->item = 1;
+            } /* else if */
+
+            else
+            {
+                unhandled = 1;
+            } /* else */
+        } /* if */
+
+        else if (event.type == EV_ABS)
+        {
+            outevent->type = MANYMOUSE_EVENT_ABSMOTION;
+            if (event.code == ABS_X)
+            {
+                outevent->item = 0;
+                outevent->minval = mouse->min_x;
+                outevent->maxval = mouse->max_x;
+            } /* if */
+            else if (event.code == ABS_Y)
+            {
+                outevent->item = 1;
+                outevent->minval = mouse->min_y;
+                outevent->maxval = mouse->max_y;
+            } /* if */
+            else
+            {
+                unhandled = 1;
+            } /* else */
+        } /* else if */
+
+        else if (event.type == EV_KEY)
+        {
+            outevent->type = MANYMOUSE_EVENT_BUTTON;
+            if ((event.code >= BTN_LEFT) && (event.code <= BTN_BACK))
+                outevent->item = event.code - BTN_MOUSE;
+
+            /* just in case some device uses this block of events instead... */
+            else if ((event.code >= BTN_MISC) && (event.code <= BTN_LEFT))
+                outevent->item = (event.code - BTN_MISC);
+
+            else if (event.code == BTN_TOUCH) /* tablet... */
+                outevent->item = 0;
+            else if (event.code == BTN_STYLUS) /* tablet... */
+                outevent->item = 1;
+            else if (event.code == BTN_STYLUS2) /* tablet... */
+                outevent->item = 2;
+
+            else
+            {
+                /*printf("unhandled mouse button: 0x%X\n", event.code);*/
+                unhandled = 1;
+            } /* else */
+        } /* else if */
+        else
+        {
+            unhandled = 1;
+        } /* else */
+    } /* while */
+
+    return 1;  /* got a valid event */
+} /* poll_mouse */
+
+
+static int init_mouse(const char *fname, int fd)
+{
+    MouseStruct *mouse = &mice[available_mice];
+    int has_absolutes = 0;
+    int is_mouse = 0;
+    unsigned char relcaps[(REL_MAX / 8) + 1];
+    unsigned char abscaps[(ABS_MAX / 8) + 1];
+    unsigned char keycaps[(KEY_MAX / 8) + 1];
+
+    memset(relcaps, '\0', sizeof (relcaps));
+    memset(abscaps, '\0', sizeof (abscaps));
+    memset(keycaps, '\0', sizeof (keycaps));
+
+    if (ioctl(fd, EVIOCGBIT(EV_KEY, sizeof (keycaps)), keycaps) == -1)
+        return 0;  /* gotta have some buttons!  :)  */
+
+    if (ioctl(fd, EVIOCGBIT(EV_REL, sizeof (relcaps)), relcaps) != -1)
+    {
+	if ( (test_bit(relcaps, REL_X)) && (test_bit(relcaps, REL_Y)) )
+        {
+            if (test_bit(keycaps, BTN_MOUSE))
+                is_mouse = 1;
+        }
+
+#if ALLOW_DIALS_TO_BE_MICE
+	if (test_bit(relcaps, REL_DIAL))
+            is_mouse = 1;  // griffin powermate?
+#endif
+    }
+
+    if (ioctl(fd, EVIOCGBIT(EV_ABS, sizeof (abscaps)), abscaps) != -1)
+    {
+        if ( (test_bit(abscaps, ABS_X)) && (test_bit(abscaps, ABS_Y)) )
+        {
+            is_mouse = 1;
+            has_absolutes = 1;
+        }
+    }
+
+    if (!is_mouse)
+        return 0;
+
+    mouse->min_x = mouse->min_y = mouse->max_x = mouse->max_y = 0;
+    if (has_absolutes)
+    {
+        struct input_absinfo absinfo;
+        if (ioctl(fd, EVIOCGABS(ABS_X), &absinfo) == -1)
+            return 0;
+        mouse->min_x = absinfo.minimum;
+        mouse->max_x = absinfo.maximum;
+
+        if (ioctl(fd, EVIOCGABS(ABS_Y), &absinfo) == -1)
+            return 0;
+        mouse->min_y = absinfo.minimum;
+        mouse->max_y = absinfo.maximum;
+    }
+
+    if (ioctl(fd, EVIOCGNAME(sizeof (mouse->name)), mouse->name) == -1)
+        snprintf(mouse->name, sizeof (mouse->name), "Unknown device");
+
+    mouse->fd = fd;
+
+    return 1;
+} /* init_mouse */
+
+
+/* Return a file descriptor if this is really a mouse, -1 otherwise. */
+static int open_if_mouse(const char *fname)
+{
+    struct stat statbuf;
+    int fd;
+    int devmajor, devminor;
+
+    if (stat(fname, &statbuf) == -1)
+        return 0;
+
+    if (S_ISCHR(statbuf.st_mode) == 0)
+        return 0;  /* not a character device... */
+
+    /* evdev node ids are major 13, minor 64-96. Is this safe to check? */
+    devmajor = (statbuf.st_rdev & 0xFF00) >> 8;
+    devminor = (statbuf.st_rdev & 0x00FF);
+    if ( (devmajor != 13) || (devminor < 64) || (devminor > 96) )
+        return 0;  /* not an evdev. */
+
+    if ((fd = open(fname, O_RDONLY | O_NONBLOCK)) == -1)
+        return 0;
+
+    if (init_mouse(fname, fd))
+        return 1;
+
+    close(fd);
+    return 0;
+} /* open_if_mouse */
+
+
+static int linux_evdev_init(void)
+{
+    DIR *dirp;
+    struct dirent *dent;
+    int i;
+
+    for (i = 0; i < MAX_MICE; i++)
+        mice[i].fd = -1;
+
+    dirp = opendir("/dev/input");
+    if (!dirp)
+        return -1;
+
+    while ((dent = readdir(dirp)) != NULL)
+    {
+        char fname[384];
+        snprintf(fname, sizeof (fname), "/dev/input/%s", dent->d_name);
+        if (open_if_mouse(fname))
+            available_mice++;
+
+    } /* while */
+
+    closedir(dirp);
+
+    return (int)available_mice;
+} /* linux_evdev_init */
+
+
+static void linux_evdev_quit(void)
+{
+    while (available_mice)
+    {
+        int fd = mice[available_mice--].fd;
+        if (fd != -1)
+            close(fd);
+    } /* while */
+} /* linux_evdev_quit */
+
+
+static const char *linux_evdev_name(unsigned int index)
+{
+    return (index < available_mice) ? mice[index].name : NULL;
+} /* linux_evdev_name */
+
+
+static int linux_evdev_poll(ManyMouseEvent *event)
+{
+    /*
+     * (i) is static so we iterate through all mice round-robin. This
+     *  prevents a chatty mouse from dominating the queue.
+     */
+    static unsigned int i = 0;
+
+    if (i >= available_mice)
+        i = 0;  /* handle reset condition. */
+
+    if (event != NULL)
+    {
+        while (i < available_mice)
+        {
+            MouseStruct *mouse = &mice[i];
+            if (mouse->fd != -1)
+            {
+                if (poll_mouse(mouse, event))
+                {
+                    event->device = i;
+                    return 1;
+                } /* if */
+            } /* if */
+            i++;
+        } /* while */
+    } /* if */
+
+    return 0;  /* no new events */
+} /* linux_evdev_poll */
+
+static const ManyMouseDriver ManyMouseDriver_interface =
+{
+    "Linux /dev/input/event* interface",
+    linux_evdev_init,
+    linux_evdev_quit,
+    linux_evdev_name,
+    linux_evdev_poll
+};
+
+const ManyMouseDriver *ManyMouseDriver_evdev = &ManyMouseDriver_interface;
+
+#else
+const ManyMouseDriver *ManyMouseDriver_evdev = 0;
+#endif  /* ifdef Linux blocker */
+
+/* end of linux_evdev.c ... */
+

--- a/Src/Inputs/Manymouse.c
+++ b/Src/Inputs/Manymouse.c
@@ -1,0 +1,95 @@
+/*
+ * ManyMouse foundation code; apps talks to this and it talks to the lowlevel
+ *  code for various platforms.
+ *
+ * Please see the file LICENSE.txt in the source's root directory.
+ *
+ *  This file written by Ryan C. Gordon.
+ */
+
+#include <stdlib.h>
+#include "Manymouse.h"
+
+static const char *manymouse_copyright =
+    "ManyMouse " MANYMOUSE_VERSION " copyright (c) 2005-2012 Ryan C. Gordon.";
+
+extern const ManyMouseDriver *ManyMouseDriver_evdev;
+extern const ManyMouseDriver *ManyMouseDriver_xinput2;
+
+/*
+ * These have to be in the favored order...obviously it doesn't matter if the
+ *  Linux driver comes before or after the Windows one, since one won't
+ *  exist on a given platform, but things like Mac OS X's hidmanager (which
+ *  only works on OS X 10.5 and later) should come before Mac OS X's
+ *  hidutilities (which works on older systems, but may stop working in 10.6
+ *  and later). In the Mac OS X case, you want to try the newer tech, and if
+ *  it's not available (on 10.4 or earlier), fall back to trying the legacy
+ *  code.
+ */
+static const ManyMouseDriver **mice_drivers[] =
+{
+    &ManyMouseDriver_xinput2,
+    &ManyMouseDriver_evdev
+};
+
+
+static const ManyMouseDriver *driver = NULL;
+
+int ManyMouse_Init(void)
+{
+    const int upper = (sizeof (mice_drivers) / sizeof (mice_drivers[0]));
+    int i;
+    int retval = -1;
+
+    /* impossible test to keep manymouse_copyright linked into the binary. */
+    if (manymouse_copyright == NULL)
+        return -1;
+
+    if (driver != NULL)
+        return -1;
+
+    for (i = 0; (i < upper) && (driver == NULL); i++)
+    {
+        const ManyMouseDriver *this_driver = *(mice_drivers[i]);
+        if (this_driver != NULL) /* if not built for this platform, skip it. */
+        {
+            const int mice = this_driver->init();
+            if (mice > retval) {
+                retval = mice; /* may move from "error" to "no mice found". */
+	    }
+
+            if (mice >= 0)
+                driver = this_driver;
+        } /* if */
+    } /* for */
+
+    return retval;
+} /* ManyMouse_Init */
+
+
+void ManyMouse_Quit(void)
+{
+    if (driver != NULL)
+    {
+        driver->quit();
+        driver = NULL;
+    } /* if */
+} /* ManyMouse_Quit */
+
+const char *ManyMouse_DriverName(void)
+{
+    return (driver) ? driver->driver_name : NULL;
+} /* ManyMouse_DriverName */
+
+const char *ManyMouse_DeviceName(unsigned int index)
+{
+    return (driver) ? driver->name(index) : NULL;
+} /* ManyMouse_DeviceName */
+
+int ManyMouse_PollEvent(ManyMouseEvent *event)
+{
+    return (driver) ? driver->poll(event) : 0;
+} /* ManyMouse_PollEvent */
+
+/* end of manymouse.c ... */
+

--- a/Src/Inputs/Manymouse.h
+++ b/Src/Inputs/Manymouse.h
@@ -1,0 +1,63 @@
+/*
+ * ManyMouse main header. Include this from your app.
+ *
+ * Please see the file LICENSE.txt in the source's root directory.
+ *
+ *  This file written by Ryan C. Gordon.
+ */
+
+#ifndef _INCLUDE_MANYMOUSE_H_
+#define _INCLUDE_MANYMOUSE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MANYMOUSE_VERSION "0.0.3"
+
+typedef enum
+{
+    MANYMOUSE_EVENT_ABSMOTION = 0,
+    MANYMOUSE_EVENT_RELMOTION,
+    MANYMOUSE_EVENT_BUTTON,
+    MANYMOUSE_EVENT_SCROLL,
+    MANYMOUSE_EVENT_DISCONNECT,
+    MANYMOUSE_EVENT_MAX
+} ManyMouseEventType;
+
+typedef struct
+{
+    ManyMouseEventType type;
+    unsigned int device;
+    unsigned int item;
+    int value;
+    int minval;
+    int maxval;
+} ManyMouseEvent;
+
+
+/* internal use only. */
+typedef struct
+{
+    const char *driver_name;
+    int (*init)(void);
+    void (*quit)(void);
+    const char *(*name)(unsigned int index);
+    int (*poll)(ManyMouseEvent *event);
+} ManyMouseDriver;
+
+
+int ManyMouse_Init(void);
+const char *ManyMouse_DriverName(void);
+void ManyMouse_Quit(void);
+const char *ManyMouse_DeviceName(unsigned int index);
+int ManyMouse_PollEvent(ManyMouseEvent *event);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* !defined _INCLUDE_MANYMOUSE_H_ */
+
+/* end of manymouse.h ... */
+

--- a/Src/Inputs/X11_xinput2.c
+++ b/Src/Inputs/X11_xinput2.c
@@ -1,0 +1,546 @@
+/*
+ * Support for the X11 XInput extension.
+ *
+ * Please see the file LICENSE.txt in the source's root directory.
+ *
+ *  This file written by Ryan C. Gordon.
+ */
+
+#include "Manymouse.h"
+
+/* Try to use this on everything but Windows and Mac OS by default... */
+#ifndef SUPPORT_XINPUT2
+#if ( (defined(_WIN32) || defined(__CYGWIN__)) )
+#define SUPPORT_XINPUT2 0
+#elif ( (defined(__MACH__)) && (defined(__APPLE__)) )
+#define SUPPORT_XINPUT2 0
+#elif __has_include(<X11/extensions/XInput2.h>)
+#include <X11/extensions/XInput2.h>
+#define SUPPORT_XINPUT2 1
+#else
+#define SUPPORT_XINPUT2 0
+#endif
+#endif
+
+#if SUPPORT_XINPUT2
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+#include <sys/select.h>
+
+/* 32 is good enough for now. */
+#define MAX_MICE 32
+#define MAX_AXIS 16
+typedef struct
+{
+    int device_id;
+    int connected;
+    int relative[MAX_AXIS];
+    int minval[MAX_AXIS];
+    int maxval[MAX_AXIS];
+    char name[64];
+} MouseStruct;
+
+static MouseStruct mice[MAX_MICE];
+static unsigned int available_mice = 0;
+
+static Display *display = NULL;
+static int xi2_opcode = 0;
+
+
+/* !!! FIXME: this is cut-and-paste between a few targets now. Move it to
+ * !!! FIXME:  manymouse.c ...
+ */
+/*
+ * Just trying to avoid malloc() here...we statically allocate a buffer
+ *  for events and treat it as a ring buffer.
+ */
+/* !!! FIXME: tweak this? */
+#define MAX_EVENTS 1024
+static ManyMouseEvent input_events[MAX_EVENTS];
+static volatile int input_events_read = 0;
+static volatile int input_events_write = 0;
+
+static void queue_event(const ManyMouseEvent *event)
+{
+    /* copy the event info. We'll process it in ManyMouse_PollEvent(). */
+    memcpy(&input_events[input_events_write], event, sizeof (ManyMouseEvent));
+
+    input_events_write = ((input_events_write + 1) % MAX_EVENTS);
+
+    /* Ring buffer full? Lose oldest event. */
+    if (input_events_write == input_events_read)
+    {
+        /* !!! FIXME: we need to not lose mouse buttons here. */
+        input_events_read = ((input_events_read + 1) % MAX_EVENTS);
+    } /* if */
+} /* queue_event */
+
+
+static int dequeue_event(ManyMouseEvent *event)
+{
+    if (input_events_read != input_events_write)  /* no events if equal. */
+    {
+        memcpy(event, &input_events[input_events_read], sizeof (*event));
+        input_events_read = ((input_events_read + 1) % MAX_EVENTS);
+        return 1;
+    } /* if */
+    return 0;  /* no event. */
+} /* dequeue_event */
+
+
+/*
+ * You _probably_ have Xlib on your system if you're on a Unix box where you
+ *  are planning to plug in multiple mice. That being said, we don't want
+ *  to force a project to add Xlib to their builds, or force the end-user to
+ *  have Xlib installed if they are otherwise running a console app that the
+ *  evdev driver would handle.
+ *
+ * We load all Xlib symbols at runtime, and fail gracefully if they aren't
+ *  available for some reason...ManyMouse might be able to use the evdev
+ *  driver or at least return a zero.
+ *
+ * On Linux (and probably others), you'll need to add -ldl to your link line,
+ *  but it's part of glibc, so this is pretty much going to be there.
+ */
+
+static void *libx11 = NULL;
+static void *libxext = NULL;
+static void *libxi = NULL;
+
+typedef int (*XExtErrHandler)(Display *, _Xconst char *, _Xconst char *);
+
+static XExtErrHandler (*pXSetExtensionErrorHandler)(XExtErrHandler h) = 0;
+static Display* (*pXOpenDisplay)(_Xconst char*) = 0;
+static int (*pXCloseDisplay)(Display*) = 0;
+static int (*pXISelectEvents)(Display*,Window,XIEventMask*,int) = 0;
+static Bool (*pXQueryExtension)(Display*,_Xconst char*,int*,int*,int*) = 0;
+static Status (*pXIQueryVersion)(Display*,int*,int*) = 0;
+static XIDeviceInfo* (*pXIQueryDevice)(Display*,int,int*) = 0;
+static void (*pXIFreeDeviceInfo)(XIDeviceInfo*) = 0;
+static Bool (*pXGetEventData)(Display*,XGenericEventCookie*) = 0;
+static void (*pXFreeEventData)(Display*,XGenericEventCookie*) = 0;
+static int (*pXNextEvent)(Display*,XEvent*) = 0;
+static int (*pXPending)(Display*) = 0;
+static int (*pXFlush)(Display*) = 0;
+static int (*pXEventsQueued)(Display*,int) = 0;
+
+static int symlookup(void *dll, void **addr, const char *sym)
+{
+    *addr = dlsym(dll, sym);
+    if (*addr == NULL)
+        return 0;
+
+    return 1;
+} /* symlookup */
+
+static int find_api_symbols(void)
+{
+    void *dll = NULL;
+
+    #define LOOKUP(x) { if (!symlookup(dll, (void **) &p##x, #x)) return 0; }
+    dll = libx11 = dlopen("libX11.so.6", RTLD_GLOBAL | RTLD_LAZY);
+    if (dll == NULL)
+        return 0;
+
+    LOOKUP(XOpenDisplay);
+    LOOKUP(XCloseDisplay);
+    LOOKUP(XGetEventData);
+    LOOKUP(XFreeEventData);
+    LOOKUP(XQueryExtension);
+    LOOKUP(XNextEvent);
+    LOOKUP(XPending);
+    LOOKUP(XFlush);
+    LOOKUP(XEventsQueued);
+
+    dll = libxext = dlopen("libXext.so.6", RTLD_GLOBAL | RTLD_LAZY);
+    if (dll == NULL)
+        return 0;
+
+    LOOKUP(XSetExtensionErrorHandler);
+
+    dll = libxi = dlopen("libXi.so.6", RTLD_GLOBAL | RTLD_LAZY);
+    if (dll == NULL)
+        return 0;
+
+    LOOKUP(XISelectEvents);
+    LOOKUP(XIQueryVersion);
+    LOOKUP(XIQueryDevice);
+    LOOKUP(XIFreeDeviceInfo);
+
+    #undef LOOKUP
+
+    return 1;
+} /* find_api_symbols */
+
+
+static void xinput2_cleanup(void)
+{
+    if (display != NULL)
+    {
+        pXCloseDisplay(display);
+        display = NULL;
+    } /* if */
+
+    memset(mice, '\0', sizeof (mice));
+    available_mice = 0;
+
+    #define LIBCLOSE(lib) { if (lib != NULL) { dlclose(lib); lib = NULL; } }
+    LIBCLOSE(libxi);
+    LIBCLOSE(libxext);
+    LIBCLOSE(libx11);
+    #undef LIBCLOSE
+
+    memset(input_events, '\0', sizeof (input_events));
+    input_events_read = input_events_write = 0;
+} /* xinput2_cleanup */
+
+
+static int init_mouse(MouseStruct *mouse, const XIDeviceInfo *devinfo)
+{
+    XIAnyClassInfo **classes = devinfo->classes;
+    int axis = 0;
+    int i = 0;
+
+    /*
+     * we only look at "slave" devices. "Master" pointers are the logical
+     *  cursors, "slave" pointers are the hardware that back them.
+     *  "Floating slaves" are hardware that don't back a cursor.
+     */
+
+    if ((devinfo->use != XISlavePointer) && (devinfo->use != XIFloatingSlave))
+        return 0;  /* not a device we care about. */
+    else if (strstr(devinfo->name, "XTEST pointer") != NULL)
+        return 0;  /* skip this nonsense. It's for the XTEST extension. */
+
+    mouse->device_id = devinfo->deviceid;
+    mouse->connected = 1;
+
+    for (i = 0; i < devinfo->num_classes; i++)
+    {
+        if ((classes[i]->type == XIValuatorClass) && (axis < MAX_AXIS))
+        {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
+            const XIValuatorClassInfo *v = (XIValuatorClassInfo*) classes[i];
+#pragma GCC diagnostic pop
+            mouse->relative[axis] = (v->mode == XIModeRelative);
+            mouse->minval[axis] = (int) v->min;
+            mouse->maxval[axis] = (int) v->max;
+            axis++;
+        } /* if */
+    } /* for */
+
+    strncpy(mouse->name, devinfo->name, sizeof (mouse->name));
+    mouse->name[sizeof (mouse->name) - 1] = '\0';
+    return 1;
+} /* init_mouse */
+
+
+static int (*Xext_handler)(Display *, _Xconst char *, _Xconst char *) = NULL;
+static int xext_errhandler(Display *d, _Xconst char *ext, _Xconst char *reason)
+{
+    /* prevent Xlib spew to stderr for missing extensions. */
+    return (strcmp(reason, "missing") == 0) ? 0 : Xext_handler(d, ext, reason);
+} /* xext_errhandler */
+
+
+static int register_for_events(Display *dpy)
+{
+    XIEventMask evmask;
+    unsigned char mask[3] = { 0, 0, 0 };
+
+    XISetMask(mask, XI_HierarchyChanged);
+    XISetMask(mask, XI_RawMotion);
+    XISetMask(mask, XI_RawButtonPress);
+    XISetMask(mask, XI_RawButtonRelease);
+
+    evmask.deviceid = XIAllDevices;
+    evmask.mask_len = sizeof (mask);
+    evmask.mask = mask;
+
+    /* !!! FIXME: retval? */
+    pXISelectEvents(dpy, DefaultRootWindow(dpy), &evmask, 1);
+    return 1;
+} /* register_for_events */
+
+
+static int x11_xinput2_init_internal(void)
+{
+    const char *ext = "XInputExtension";
+    XIDeviceInfo *device_list = NULL;
+    int device_count = 0;
+    int available = 0;
+    int event = 0;
+    int error = 0;
+    int major = 2;
+    int minor = 0;
+    int i = 0;
+
+    xinput2_cleanup();  /* just in case... */
+
+    if (getenv("MANYMOUSE_NO_XINPUT2") != NULL)
+        return -1;
+
+    if (!find_api_symbols())
+        return -1;  /* couldn't find all needed symbols. */
+
+    display = pXOpenDisplay(NULL);
+    if (display == NULL)
+        return -1;  /* no X server at all */
+
+    Xext_handler = pXSetExtensionErrorHandler(xext_errhandler);
+    available = (pXQueryExtension(display, ext, &xi2_opcode, &event, &error) &&
+                 (pXIQueryVersion(display, &major, &minor) != BadRequest));
+    pXSetExtensionErrorHandler(Xext_handler);
+    Xext_handler = NULL;
+
+    if (!available)
+        return -1;  /* no XInput2 support. */
+
+    /*
+     * Register for events first, to prevent a race where we unplug a
+     *  device between when we queried for the list and when we start
+     *  listening for changes.
+     */
+    if (!register_for_events(display))
+        return -1;
+
+    device_list = pXIQueryDevice(display, XIAllDevices, &device_count);
+    for (i = 0; i < device_count; i++)
+    {
+        MouseStruct *mouse = &mice[available_mice];
+        if (init_mouse(mouse, &device_list[i]))
+            available_mice++;
+    } /* for */
+    pXIFreeDeviceInfo(device_list);
+
+    return (int)available_mice;
+} /* x11_xinput2_init_internal */
+
+
+static int x11_xinput2_init(void)
+{
+    int retval = x11_xinput2_init_internal();
+    if (retval < 0)
+        xinput2_cleanup();
+    return retval;
+} /* x11_xinput2_init */
+
+
+static void x11_xinput2_quit(void)
+{
+    xinput2_cleanup();
+} /* x11_xinput2_quit */
+
+
+static const char *x11_xinput2_name(unsigned int index)
+{
+    return (index < available_mice) ? mice[index].name : NULL;
+} /* x11_xinput2_name */
+
+
+static int find_mouse_by_devid(const int devid)
+{
+    int i;
+    const MouseStruct *mouse = mice;
+
+    for (i = 0; i < (int)available_mice; i++, mouse++)
+    {
+        if (mouse->device_id == devid)
+            return (mouse->connected) ? i : -1;
+    } /* for */
+
+    return -1;
+} /* find_mouse_by_devid */
+
+
+static int get_next_x11_event(XEvent *xev)
+{
+    int available = 0;
+
+    pXFlush(display);
+    if (pXEventsQueued(display, QueuedAlready))
+        available = 1;
+    else
+    {
+        /* XPending() blocks if there's no data, so select() first. */
+        struct timeval nowait;
+        const int fd = ConnectionNumber(display);
+        fd_set fdset;
+        FD_ZERO(&fdset);
+        FD_SET(fd, &fdset);
+        memset(&nowait, '\0', sizeof (nowait));
+        if (select(fd+1, &fdset, NULL, NULL, &nowait) == 1)
+            available = pXPending(display);
+    } /* else */
+
+    if (available)
+    {
+        memset(xev, '\0', sizeof (*xev));
+        pXNextEvent(display, xev);
+        return 1;
+    } /* if */
+
+    return 0;
+} /* get_next_x11_event */
+
+
+/* Everything else returns left (0), right (1), middle (2)...XI2 returns
+   right and middle in reverse, so swap them ourselves. */
+static inline int map_xi2_button(const int button)
+{
+    if (button == 2)
+        return 3;
+    else if (button == 3)
+        return 2;
+    return button;
+} /* map_xi2_button */
+
+
+static void pump_events(void)
+{
+    ManyMouseEvent event;
+    const int opcode = xi2_opcode;
+    const XIRawEvent *rawev = NULL;
+    const XIHierarchyEvent *hierev = NULL;
+    int mouse = 0;
+    XEvent xev;
+    int i = 0;
+
+    while (get_next_x11_event(&xev))
+    {
+        /* All XI2 events are "cookie" events...which need extra tapdance. */
+        if (xev.xcookie.type != GenericEvent)
+            continue;
+        else if (xev.xcookie.extension != opcode)
+            continue;
+        else if (!pXGetEventData(display, &xev.xcookie))
+            continue;
+
+        switch (xev.xcookie.evtype)
+        {
+            case XI_RawMotion:
+                rawev = (const XIRawEvent *) xev.xcookie.data;
+                mouse = find_mouse_by_devid(rawev->deviceid);
+                if (mouse != -1)
+                {
+                    const double *values = rawev->raw_values;
+                    int top = rawev->valuators.mask_len * 8;
+                    if (top > MAX_AXIS)
+                        top = MAX_AXIS;
+
+                    for (i = 0; i < top; i++)
+                    {
+                        if (XIMaskIsSet(rawev->valuators.mask, i))
+                        {
+                            const int value = (int) *values;
+                            if (mice[mouse].relative[i])
+                                event.type = MANYMOUSE_EVENT_RELMOTION;
+                            else
+                                event.type = MANYMOUSE_EVENT_ABSMOTION;
+                            event.device = (unsigned int)mouse;
+                            event.item = (unsigned int)i;
+                            event.value = value;
+                            event.minval = mice[mouse].minval[i];
+                            event.maxval = mice[mouse].maxval[i];
+                            if ((!mice[mouse].relative[i]) || (value))
+                                queue_event(&event);
+                            values++;
+                        } /* if */
+                    } /* for */
+                } /* if */
+                break;
+
+            case XI_RawButtonPress:
+            case XI_RawButtonRelease:
+                rawev = (const XIRawEvent *) xev.xcookie.data;
+                mouse = find_mouse_by_devid(rawev->deviceid);
+                if (mouse != -1)
+                {
+                    const int button = map_xi2_button(rawev->detail);
+                    const int pressed = (xev.xcookie.evtype==XI_RawButtonPress);
+
+                    /* gah, XInput2 still maps the wheel to buttons. */
+                    if ((button >= 4) && (button <= 7))
+                    {
+                        if (pressed)  /* ignore "up" for these "buttons" */
+                        {
+                            event.type = MANYMOUSE_EVENT_SCROLL;
+                            event.device = (unsigned int)mouse;
+
+                            if ((button == 4) || (button == 5))
+                                event.item = 0;
+                            else
+                                event.item = 1;
+
+                            if ((button == 4) || (button == 6))
+                                event.value = 1;
+                            else
+                                event.value = -1;
+
+                            queue_event(&event);
+                        } /* if */
+                    } /* if */
+                    else
+                    {
+                        event.type = MANYMOUSE_EVENT_BUTTON;
+                        event.device = (unsigned int)mouse;
+                        event.item = (unsigned int)button-1;
+                        event.value = pressed;
+                        queue_event(&event);
+                    } /* else */
+                } /* if */
+                break;
+
+            case XI_HierarchyChanged:
+                hierev = (const XIHierarchyEvent *) xev.xcookie.data;
+                for (i = 0; i < hierev->num_info; i++)
+                {
+                    if (hierev->info[i].flags & XISlaveRemoved)
+                    {
+                        mouse = find_mouse_by_devid(hierev->info[i].deviceid);
+                        if (mouse != -1)
+                        {
+                            mice[mouse].connected = 0;
+                            event.type = MANYMOUSE_EVENT_DISCONNECT;
+                            event.device = (unsigned int)mouse;
+                            queue_event(&event);
+                        } /* if */
+                    } /* if */
+                } /* for */
+                break;
+        } /* switch */
+
+        pXFreeEventData(display, &xev.xcookie);
+    } /* while */
+} /* pump_events */
+
+static int x11_xinput2_poll(ManyMouseEvent *event)
+{
+    if (dequeue_event(event))  /* ...favor existing events in the queue... */
+        return 1;
+
+    pump_events();  /* pump runloop for new hardware events... */
+    return dequeue_event(event);  /* see if anything had shown up... */
+} /* x11_xinput2_poll */
+
+static const ManyMouseDriver ManyMouseDriver_interface =
+{
+    "X11 XInput2 extension",
+    x11_xinput2_init,
+    x11_xinput2_quit,
+    x11_xinput2_name,
+    x11_xinput2_poll
+};
+
+const ManyMouseDriver *ManyMouseDriver_xinput2 = &ManyMouseDriver_interface;
+
+#else
+const ManyMouseDriver *ManyMouseDriver_xinput2 = 0;
+#endif /* SUPPORT_XINPUT2 blocker */
+
+/* end of x11_xinput2.c ... */
+

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -95,6 +95,8 @@ static Util::Config::Node s_runtime_config("Global");
 
 SDL_Window *s_window = nullptr;
 
+SDL_Window *get_window() { return s_window; }
+
 /*
  * Position and size of rectangular region within OpenGL display to render to.
  * Unlike the config tree, these end up containing the actual resolution (and
@@ -104,6 +106,9 @@ SDL_Window *s_window = nullptr;
 static unsigned  xOffset, yOffset;      // offset of renderer output within OpenGL viewport
 static unsigned  xRes, yRes;            // renderer output resolution (can be smaller than GL viewport)
 static unsigned  totalXRes, totalYRes;  // total resolution (the whole GL viewport)
+
+unsigned int get_total_width() { return totalXRes; }
+unsigned int get_total_height() { return totalYRes; }
 
 static bool SetGLGeometry(unsigned *xOffsetPtr, unsigned *yOffsetPtr, unsigned *xResPtr, unsigned *yResPtr, unsigned *totalXResPtr, unsigned *totalYResPtr, bool keepAspectRatio)
 {

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1110,6 +1110,8 @@ int Supermodel(const Game &game, ROMSet *rom_set, IEmulator *Model3, CInputs *In
 
   // Hide mouse if fullscreen, enable crosshairs for gun games
   Inputs->GetInputSystem()->SetMouseVisibility(!s_runtime_config["FullScreen"].ValueAs<bool>());
+  if (!s_runtime_config["FullScreen"].ValueAs<bool>())
+      Inputs->GetInputSystem()->SetMouseVisibility(s_runtime_config["MouseCursor"].ValueAs<bool>());
   gameHasLightguns = !!(game.inputs & (Game::INPUT_GUN1|Game::INPUT_GUN2));
   gameHasLightguns |= game.name == "lostwsga";
   currentInputs = game.inputs;
@@ -1288,6 +1290,8 @@ int Supermodel(const Game &game, ROMSet *rom_set, IEmulator *Model3, CInputs *In
       Render3D->UploadTextures(0, 0, 0, 2048, 2048);    // sync texture memory
 
       Inputs->GetInputSystem()->SetMouseVisibility(!s_runtime_config["FullScreen"].ValueAs<bool>());
+      if (!s_runtime_config["FullScreen"].ValueAs<bool>())
+          Inputs->GetInputSystem()->SetMouseVisibility(s_runtime_config["MouseCursor"].ValueAs<bool>());
     }
     else if (Inputs->uiSaveState->Pressed())
     {
@@ -1643,6 +1647,7 @@ static Util::Config::Node DefaultConfig()
   config.Set("RefreshRate", 60.0f);
   config.Set("ShowFrameRate", false);
   config.Set("Crosshairs", int(0));
+  config.Set("MouseCursor", true);
   config.Set("FlipStereo", false);
 #ifdef SUPERMODEL_WIN32
   config.Set("InputSystem", "dinput");
@@ -1726,6 +1731,7 @@ static void Help(void)
   puts("  -show-fps               Display frame rate in window title bar");
   puts("  -crosshairs=<n>         Crosshairs configuration for gun games:");
   puts("                          0=none [Default], 1=P1 only, 2=P2 only, 3=P1 & P2");
+  puts("  -nomousecursor          Disable desktop mouse cursor in Windowed mode");
   puts("  -new3d                  New 3D engine by Ian Curtis [Default]");
   puts("  -quad-rendering         Enable proper quad rendering");
   puts("  -legacy3d               Legacy 3D engine (faster but less accurate)");
@@ -1860,6 +1866,7 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
     { "-no-dsb",              { "EmulateDSB",       false } },
     { "-legacy-scsp",         { "LegacySoundDSP",   true } },
     { "-new-scsp",            { "LegacySoundDSP",   false } },
+    { "-nomousecursor",       { "MouseCursor",      false } },
 #ifdef NET_BOARD
     { "-net",                 { "Network",       true } },
     { "-no-net",              { "Network",       false } },

--- a/Src/OSD/SDL/SDLIncludes.h
+++ b/Src/OSD/SDL/SDLIncludes.h
@@ -45,4 +45,9 @@
 #endif
 #endif
 
+
+SDL_Window *get_window();
+unsigned int get_total_width();
+unsigned int get_total_height();
+
 #endif  // INCLUDED_SDLINCLUDES_H

--- a/Src/OSD/SDL/SDLInputSystem.h
+++ b/Src/OSD/SDL/SDLInputSystem.h
@@ -43,6 +43,9 @@ struct SDLKeyMapStruct
 	SDL_Scancode sdlKey;
 };
 
+
+#define MAX_MICE 32
+
 /*
  * Input system that uses SDL.
  */
@@ -63,12 +66,12 @@ private:
 	// Current key state obtained from SDL
 	const Uint8 *m_keyState;
 
-	// Current mouse state obtained from SDL
-	int m_mouseX;
-	int m_mouseY;
-	int m_mouseZ;
-	short m_mouseWheelDir;
-	Uint8 m_mouseButtons;
+	// Current mouse state obtained from ManyMouse
+	int m_mouseX[MAX_MICE];
+	int m_mouseY[MAX_MICE];
+	int m_mouseZ[MAX_MICE];
+	short m_mouseWheelDir[MAX_MICE];
+	Uint8 m_mouseButtons[MAX_MICE];
 
 	// SDL2 ffb
 	SDL_HapticEffect eff;
@@ -85,6 +88,23 @@ private:
 		int effectFrictionForceID = -1;
 	};
 	std::vector<hapticInfo> m_SDLHapticDatas;
+
+	struct Mouse
+	{
+		int connected;
+		int x;
+		int y;
+		int relx;
+		int rely;
+		SDL_Color color;
+		char name[MAX_NAME_LENGTH + 1];
+		Uint32 buttons;
+		Uint32 scrolluptick;
+		Uint32 scrolldowntick;
+		Uint32 scrolllefttick;
+		Uint32 scrollrighttick;
+	};
+	std::vector<MouseDetails> m_mseDetails;
 
 	/*
 	 * Opens all attached joysticks.


### PR DESCRIPTION
 This removes SDL_Mouse polling and replaces with
 Ryan C. Gordon's ManyMouse libraries: https://github.com/icculus/manymouse

 This affects Linux only. It uses X11 XInput and evdev polling when available.

 Replicates rawinput (Windows) in Linux.

 2 player gun games now work, as can be seen in: https://youtu.be/qplfGymaDPI