### PR TITLE
Amelioration for networked multiplayer on single machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,42 @@ For network support:
 ```
 make -f Makefiles/Makefile.UNIX NET_BOARD=1
 ```
+
+### macOS
+
+Ensure Apple's Xcode Command Line Tools are installed:
+
+From a terminal:
+```
+xcode-select --install
+```
+
+Ensure SDL2 is installed.  Download the latest *.dmg files from both of the links below, and install per the READMEs in the .dmgs (i.e. in "/Library/Frameworks")
+
+* SDL2: https://github.com/libsdl-org/SDL/releases
+
+* SDL_net: https://github.com/libsdl-org/SDL_net/releases
+
+
+And then build Supermodel:
+
+```
+make -f Makefiles/Makefile.OSX
+```
+
+For network support:
+
+```
+make -f Makefiles/Makefile.OSX NET_BOARD=1
+```
+
+### Note: running on macOS
+If you try and run a macOS binary that was downloaded from the internet and/or built on a different machine, you need to grant macOS permission to execute the binary (just 1-time):
+
+* Open the folder containing the binary in Finder, and right (or ctrl) click on it:
+
+* Click "Open" when the following dialogue box appears : "macOS cannot verify the developer of “supermodel-git-xxxx”. Are you sure you want to open it?"
+
+* Close the terminal window that opens (after clicking open)
+
+Details: https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -177,7 +177,7 @@ static void GLAPIENTRY DebugCallback(GLenum source, GLenum type, GLuint id, GLen
 }
 
 // In windows with an nvidia card (sorry not tested anything else) you can customise the resolution.
-// This also allows you to set a totally custom refresh rate. Apparently you can drive most monitors at 
+// This also allows you to set a totally custom refresh rate. Apparently you can drive most monitors at
 // 57.5fps with no issues. Anyway this code will automatically pick up your custom refresh rate, and set it if it exists
 // It it doesn't exist, then it'll probably just default to 60 or whatever your refresh rate is.
 static void SetFullScreenRefreshRate()
@@ -828,7 +828,7 @@ private:
         const char* vertexShader = R"glsl(
 
             #version 410 core
-             
+
             uniform mat4 mvp;
             layout(location = 0) in vec3 inVertices;
 
@@ -841,7 +841,7 @@ private:
         const char* fragmentShader = R"glsl(
 
             #version 410 core
-             
+
             uniform vec4 colour;
             out vec4 fragColour;
 
@@ -1087,15 +1087,10 @@ int Supermodel(const Game &game, ROMSet *rom_set, IEmulator *Model3, CInputs *In
   SDL_SetWindowTitle(s_window, baseTitleStr);
   SDL_SetWindowSize(s_window, totalXRes, totalYRes);
 
-  if (!s_runtime_config["WindowXPosition"].Empty() && !s_runtime_config["WindowYPosition"].Empty())
-  {
-    SDL_SetWindowPosition(s_window, s_runtime_config["WindowXPosition"].ValueAs<unsigned>(), s_runtime_config["WindowYPosition"].ValueAs<unsigned>());
-  }
-  else
-  {
-    SDL_SetWindowPosition(s_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-  }
-  
+  int xpos = s_runtime_config["WindowXPosition"].Exists() ? s_runtime_config["WindowXPosition"].ValueAs<int>() : SDL_WINDOWPOS_CENTERED;
+  int ypos = s_runtime_config["WindowYPosition"].Exists() ? s_runtime_config["WindowYPosition"].ValueAs<int>() : SDL_WINDOWPOS_CENTERED;
+  SDL_SetWindowPosition(s_window, xpos, ypos);
+
   if (s_runtime_config["BorderlessWindow"].ValueAs<bool>())
   {
     SDL_SetWindowBordered(s_window, SDL_FALSE);
@@ -1642,8 +1637,8 @@ static Util::Config::Node DefaultConfig()
   config.Set("QuadRendering", false);
   config.Set("XResolution", "496");
   config.Set("YResolution", "384");
-  config.Set("WindowXPosition", "NA");
-  config.Set("WindowYPosition", "NA");
+  config.SetEmpty("WindowXPosition");
+  config.SetEmpty("WindowYPosition");
   config.Set("FullScreen", false);
   config.Set("BorderlessWindow", false);
 
@@ -1725,7 +1720,7 @@ static void Help(void)
   puts("");
   puts("Video Options:");
   puts("  -res=<x>,<y>            Resolution [Default: 496,384]");
-  puts("  -window-pos=<x>,<y>     Window position [Default: centered]");  
+  puts("  -window-pos=<x>,<y>     Window position [Default: centered]");
   puts("  -window                 Windowed mode [Default]");
   puts("  -borderless             Windowed mode with no border");
   puts("  -fullscreen             Full screen mode");
@@ -1966,13 +1961,11 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
           }
           else
           {
-              unsigned  x, y;
-              if (2 == sscanf(&argv[i][4], "=%u,%u", &x, &y))
+              int xpos, ypos;
+              if (2 == sscanf(&argv[i][11], "=%d,%d", &xpos, &ypos))
               {
-                  std::string xres = Util::Format() << x;
-                  std::string yres = Util::Format() << y;
-                  cmd_line.config.Set("WindowXPosition", xres);
-                  cmd_line.config.Set("WindowYPosition", yres);
+                  cmd_line.config.Set("WindowXPosition", xpos);
+                  cmd_line.config.Set("WindowYPosition", ypos);
               }
               else
               {

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1087,11 +1087,10 @@ int Supermodel(const Game &game, ROMSet *rom_set, IEmulator *Model3, CInputs *In
   SDL_SetWindowTitle(s_window, baseTitleStr);
   SDL_SetWindowSize(s_window, totalXRes, totalYRes);
 
-  if (  s_runtime_config["Xpos"].ValueAs<std::string>() != "NA" &&
-        s_runtime_config["Ypos"].ValueAs<std::string>() != "NA" )
+  if ( !s_runtime_config["Xpos"].Empty() && !s_runtime_config["Xpos"].Empty())
     SDL_SetWindowPosition(s_window, s_runtime_config["Xpos"].ValueAs<unsigned>(), s_runtime_config["Ypos"].ValueAs<unsigned>());
   else  
-  SDL_SetWindowPosition(s_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+    SDL_SetWindowPosition(s_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
   
   if (s_runtime_config["BorderLess"].ValueAs<bool>())
     SDL_SetWindowBordered(s_window, SDL_FALSE);

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1093,7 +1093,7 @@ int Supermodel(const Game &game, ROMSet *rom_set, IEmulator *Model3, CInputs *In
   }
   else
   {
-      SDL_SetWindowPosition(s_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+    SDL_SetWindowPosition(s_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
   }
   
   if (s_runtime_config["BorderlessWindow"].ValueAs<bool>())
@@ -1725,7 +1725,7 @@ static void Help(void)
   puts("");
   puts("Video Options:");
   puts("  -res=<x>,<y>            Resolution [Default: 496,384]");
-  puts("  -window-pos=<x>,<y>     Position [Default: centered]");  
+  puts("  -window-pos=<x>,<y>     Window position [Default: centered]");  
   puts("  -window                 Windowed mode [Default]");
   puts("  -borderless             Windowed mode with no border");
   puts("  -fullscreen             Full screen mode");

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1087,13 +1087,19 @@ int Supermodel(const Game &game, ROMSet *rom_set, IEmulator *Model3, CInputs *In
   SDL_SetWindowTitle(s_window, baseTitleStr);
   SDL_SetWindowSize(s_window, totalXRes, totalYRes);
 
-  if ( !s_runtime_config["Xpos"].Empty() && !s_runtime_config["Xpos"].Empty())
-    SDL_SetWindowPosition(s_window, s_runtime_config["Xpos"].ValueAs<unsigned>(), s_runtime_config["Ypos"].ValueAs<unsigned>());
-  else  
-    SDL_SetWindowPosition(s_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+  if (!s_runtime_config["WindowXPosition"].Empty() && !s_runtime_config["WindowYPosition"].Empty())
+  {
+    SDL_SetWindowPosition(s_window, s_runtime_config["WindowXPosition"].ValueAs<unsigned>(), s_runtime_config["WindowYPosition"].ValueAs<unsigned>());
+  }
+  else
+  {
+      SDL_SetWindowPosition(s_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
+  }
   
-  if (s_runtime_config["BorderLess"].ValueAs<bool>())
+  if (s_runtime_config["BorderlessWindow"].ValueAs<bool>())
+  {
     SDL_SetWindowBordered(s_window, SDL_FALSE);
+  }
 
   SetFullScreenRefreshRate();
 
@@ -1636,10 +1642,10 @@ static Util::Config::Node DefaultConfig()
   config.Set("QuadRendering", false);
   config.Set("XResolution", "496");
   config.Set("YResolution", "384");
-  config.Set("XPos", "NA");
-  config.Set("YPos", "NA");
+  config.Set("WindowXPosition", "NA");
+  config.Set("WindowYPosition", "NA");
   config.Set("FullScreen", false);
-  config.Set("BorderLess", false);
+  config.Set("BorderlessWindow", false);
 
   config.Set("WideScreen", false);
   config.Set("Stretch", false);
@@ -1719,7 +1725,7 @@ static void Help(void)
   puts("");
   puts("Video Options:");
   puts("  -res=<x>,<y>            Resolution [Default: 496,384]");
-  puts("  -pos=<x>,<y>            Position [Default: centered]");  
+  puts("  -window-pos=<x>,<y>     Position [Default: centered]");  
   puts("  -window                 Windowed mode [Default]");
   puts("  -borderless             Windowed mode with no border");
   puts("  -fullscreen             Full screen mode");
@@ -1843,7 +1849,7 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
     { "-no-gpu-thread",       { "GPUMultiThreaded", false } },
     { "-window",              { "FullScreen",       false } },
     { "-fullscreen",          { "FullScreen",       true } },
-    { "-borderless",          { "BorderLess",       true } },
+    { "-borderless",          { "BorderlessWindow", true } },
     { "-no-wide-screen",      { "WideScreen",       false } },
     { "-wide-screen",         { "WideScreen",       true } },
     { "-stretch",             { "Stretch",          true } },
@@ -1950,12 +1956,12 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
           }
         }
       }
-      else if (arg == "-pos" || arg.find("-pos=") == 0)
+      else if (arg == "-window-pos" || arg.find("-window-pos=") == 0)
       {
           std::vector<std::string> parts = Util::Format(arg).Split('=');
           if (parts.size() != 2)
           {
-              ErrorLog("'-pos' requires both a X and Y (e.g., '-pos=10,0').");
+              ErrorLog("'-window-pos' requires both an X and Y position (e.g., '-window-pos=10,0').");
               cmd_line.error = true;
           }
           else
@@ -1965,12 +1971,12 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
               {
                   std::string xres = Util::Format() << x;
                   std::string yres = Util::Format() << y;
-                  cmd_line.config.Set("Xpos", xres);
-                  cmd_line.config.Set("Ypos", yres);
+                  cmd_line.config.Set("WindowXPosition", xres);
+                  cmd_line.config.Set("WindowYPosition", yres);
               }
               else
               {
-                  ErrorLog("'-pos' requires both a X and Y (e.g., '-pos=10,0').");
+                  ErrorLog("'-window-pos' requires both an X and Y position (e.g., '-window-pos=10,0').");
                   cmd_line.error = true;
               }
           }

--- a/Src/OSD/SDL/SDLInputSystem.cpp
+++ b/Src/OSD/SDL/SDLInputSystem.cpp
@@ -192,6 +192,11 @@ void CSDLInputSystem::OpenJoysticks()
   int numHapticAxes = 0;
   int possibleEffect = 0;
 
+  //allow joystick to be fetch if windows has no focus.
+  //this is usefull for multiple instance networked on the same machine
+  SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+
+
   for (int joyNum = 0; joyNum < numJoys; joyNum++)
   {
     numHapticAxes = 0;

--- a/Src/Util/NewConfig.cpp
+++ b/Src/Util/NewConfig.cpp
@@ -7,7 +7,7 @@
  *
  * A hierarchical data structure supporting arbitrary nesting. Each node
  * (Config::Node) has a key and either a value or children (in fact, it may
- * have both, but this rarely makes semantic sense and so the config tree 
+ * have both, but this rarely makes semantic sense and so the config tree
  * builders take care not to allow it).
  *
  * Nesting is denoted with the '/' separator. For example:
@@ -20,10 +20,10 @@
  * [1] accesses the value of the node (more on this below). [2] accesses the
  * a child node with key "foo". [3] accesses the value of the child node "foo".
  * [4] accesses child "bar" of child "foo", and so forth.
- * 
+ *
  * Similar to map semantics, the operator [] never fails. If the node does not
  * exist, it creates a dummy "missing" node that is retained as a hidden child.
- * This node will have an empty value, which cannot be accessed, except using 
+ * This node will have an empty value, which cannot be accessed, except using
  * the ValueAsDefault<> method. This scheme exists to simplify lookup code for
  * keys known at compile time, the logic being that any "missing" key should
  * could just as well have been there in the first place, thus making the added
@@ -39,7 +39,7 @@
  *
  * Nodes at the same nesting level (siblings) are strung together in a
  * linked list. Parents also maintain pointers to the first and last of their
- * children (for order-preserving iteration) as well as a map for direct 
+ * children (for order-preserving iteration) as well as a map for direct
  * lookup by key.
  *
  * Keys may be reused at a given level. Key-value pairs will have their order
@@ -80,7 +80,7 @@
  *
  * Conversions as supported but are implemented via serialization and de-
  * serialization using sstream. Most "sane" conversions will work as expected.
- * When a conversion to T is desired, or if the stored value type is not 
+ * When a conversion to T is desired, or if the stored value type is not
  * precisely known, use:
  *
  *    node.ValueAs<T>()
@@ -103,7 +103,7 @@
  *  - Section nodes have their key set to the section name and value empty.
  *    They are the only nodes that can have children (i.e., IsLeaf() == false,
  *    HasChildren() == true).
- *  - Top-level node in the tree is the global section, and its key is 
+ *  - Top-level node in the tree is the global section, and its key is
  *    "Global".
  *  - Only the global section (top-level section) may have child nodes that are
  *    sections. The config tree can therefore only be up to 2 levels deep: the
@@ -133,7 +133,7 @@
  *    [ Section4, , Section5 ]
  *    SettingX = bar
  *
- * In this example, SettingX will be set to "foo" in Section1, Section2, and 
+ * In this example, SettingX will be set to "foo" in Section1, Section2, and
  * Section3. It will be set to "bar" in Section4, Section5, and the "Global"
  * section because of the unnamed element.
  *
@@ -147,6 +147,7 @@
  */
 
 #include "Util/NewConfig.h"
+#include <iostream>
 
 namespace Util
 {
@@ -251,8 +252,36 @@ namespace Util
       return os.str();
     }
 
+    // Adds an empty node (no value and where Empty() will return true)
+    Node &Node::AddEmpty(const std::string &path)
+    {
+      std::vector<std::string> keys = Util::Format(path).Split('/');
+      Node *parent = this;
+      ptr_t node;
+      for (size_t i = 0; i < keys.size(); i++)
+      {
+        bool leaf = i == keys.size() - 1;
+        auto it = parent->m_children.find(keys[i]);
+        if (leaf || it == parent->m_children.end())
+        {
+          // Create node at this level and leave it empty
+          node = std::make_shared<Node>(keys[i]);
+          // Attach node to parent and move down to next nesting level: last
+          // created node is new parent
+          AddChild(*parent, node);
+          parent = node.get();
+        }
+        else
+        {
+          // Descend deeper...
+          parent = it->second.get();
+        }
+      }
+      return *node;
+    }
+
     // Adds a newly-created node (which, among other things, implies no
-    // children) as a child 
+    // children) as a child
     void Node::AddChild(Node &parent, ptr_t &node)
     {
       if (!parent.m_last_child)
@@ -264,7 +293,7 @@ namespace Util
       {
         parent.m_last_child->m_next_sibling = node;
         parent.m_last_child = node;
-      }    
+      }
       parent.m_children[node->m_key] = node;
     }
 
@@ -290,7 +319,7 @@ namespace Util
       m_last_child.swap(rhs.m_last_child);
       m_children.swap(rhs.m_children);
      const_cast<std::string *>(&m_key)->swap(*const_cast<std::string *>(&rhs.m_key));
-      m_value.swap(rhs.m_value); 
+      m_value.swap(rhs.m_value);
     }
 
     Node &Node::operator=(const Node &rhs)
@@ -339,6 +368,21 @@ namespace Util
     Node::~Node()
     {
       //std::cout << ">>> Destroyed " << m_key << " (" << this << ")" << std::endl;
+    }
+
+    void PrintConfigTree(const Node &config, int indent_level, int tab_stops)
+    {
+      std::fill_n(std::ostream_iterator<char>(std::cout), tab_stops * indent_level, ' ');
+      std::cout << config.Key();
+      if (config.Exists())
+      {
+        std::cout << " = " << config.ValueAs<std::string>();
+      }
+      std::cout << std::endl;
+      for (const Node &child: config)
+      {
+        PrintConfigTree(child, indent_level + 1, tab_stops);
+      }
     }
   } // Config
 } // Util


### PR DESCRIPTION
- Allow joystick to be fetch if windows has no focus in SDL input mode
- Add video settings:
      `-window-pos=<x>,<y>`            Position [Default: centered]
      `-borderless`             Windowed mode with no border
These 2 settings are usefull when setting up a multiplayer game on one machine.

Example for 4 windows in fullHD:
`start /D"Master" Supermodel.exe -input-system=sdl dayto2pe.zip -res=960,540 -borderless -window-pos=0,0`
`start /D"Slave1" Supermodel.exe -input-system=sdl dayto2pe.zip -res=960,540 -borderless -window-pos=960,0`
`start /D"Slave2" Supermodel.exe -input-system=sdl dayto2pe.zip -res=960,540 -borderless -window-pos=0,540`
`start /D"Slave3" Supermodel.exe -input-system=sdl dayto2pe.zip -res=960,540 -borderless -window-pos=960,540`

