### PR TITLE
Fix GCC 13 build.

### DIFF
--- a/Src/Util/BitCast.h
+++ b/Src/Util/BitCast.h
@@ -3,6 +3,7 @@
 
 #include <stdexcept>
 #include <cstring>
+#include <cstdint>
 
 namespace Util
 {


### PR DESCRIPTION
MSYS and probably a few Linux distros are now shipping GCC 13, causing a build error.
The new standards and issues are listed here,
https://gcc.gnu.org/gcc-13/porting_to.html