### PR TITLE
Add description of swtrilgy patch from MAME

### DIFF
--- a/Config/Games.xml
+++ b/Config/Games.xml
@@ -2273,8 +2273,8 @@
     <roms>
       <patches>
         <!--
-          The purpose of this patch from MAME is no longer clear. Force feedback
-          or JTAG related? If anyone knows, please update this note.
+          Patch from MAME: forces JTAG write/read tests to succeed, otherwise
+          the game spins in a loop forever (until we implement JTAG properly)
         -->
         <patch region="crom" bits="32" offset="0xf6e44" value="0x60000000" />
       </patches>
@@ -2362,10 +2362,7 @@
     </hardware>
     <roms>
       <patches>
-        <!--
-          The purpose of this patch from MAME is no longer clear. Force feedback
-          or JTAG related? If anyone knows, please update this note.
-        -->
+        <!-- Patch from MAME, see swtrilgy for details -->
         <patch region="crom" bits="32" offset="0xf6dd0" value="0x60000000" />
       </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">


### PR DESCRIPTION
Star Wars Trilogy will sometimes write to a JTAG register and then read it back to verify it, but this doesn't work correctly with Supermodel's current (incomplete) JTAG implementation; it will try again and never succeed, getting stuck in an infinite loop. This patch stops the code from branching up and trying the write/read cycle again, allowing the subroutine to continue normally.