### PR TITLE
Drive board uses the value 0xFF (not 0x00) on ports 42 and 45 to stop…

### DIFF
--- a/Src/Model3/DriveBoard/JoystickBoard.cpp
+++ b/Src/Model3/DriveBoard/JoystickBoard.cpp
@@ -497,7 +497,7 @@ void CJoyBoard::ProcessEncoderCmdJoystick(void)
 
         case 0xFF:
         // Stop all effects
-        if (m_port42Out == 0 || m_port45Out == 0)
+        if (m_port42Out == 0xFF && m_port45Out == 0xFF)
           SendStopAll();
         break;
 

--- a/Src/Model3/DriveBoard/WheelBoard.cpp
+++ b/Src/Model3/DriveBoard/WheelBoard.cpp
@@ -591,7 +591,7 @@ void CWheelBoard::ProcessEncoderCmd(void)
 
       case 0xFF:
         // Stop all effects
-        if (m_port42Out == 0)
+        if (m_port42Out == 0xFF)
           SendStopAll();
         break;
 


### PR DESCRIPTION
Fixes FFB effects continuing after game ends