### PR TITLE
Prevent "ROLLING START" scrolling glitch in Scud Race

### DIFF
--- a/Config/Games.xml
+++ b/Config/Games.xml
@@ -1443,6 +1443,10 @@
       </inputs>
     </hardware>
     <roms>
+      <patches>
+        <!-- Prevent "rolling start" scrolling glitch -->
+        <patch region="crom" bits="32" offset="0x14BDB8" value="0x20B201E0" />
+      </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-19691.20" crc32="0x83523B89" />
         <file offset="2" name="epr-19690.19" crc32="0x25F007FE" />
@@ -1531,6 +1535,8 @@
       <patches>
         <!-- Secret debug menu -->
         <patch region="crom" bits="32" offset="0x199DE8" value="0x00050208" />
+        <!-- Prevent "rolling start" scrolling glitch -->
+        <patch region="crom" bits="32" offset="0x14BDF4" value="0x20B201E0" />
       </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-19734.20" crc32="0xBE897336" />
@@ -1563,6 +1569,10 @@
       </inputs>
     </hardware>
     <roms>
+      <patches>
+        <!-- Prevent "rolling start" scrolling glitch -->
+        <patch region="crom" bits="32" offset="0x146350" value="0x20B201E0" />
+      </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-19607a.20" crc32="0x24301A12" />
         <file offset="2" name="epr-19608a.19" crc32="0x1426160E" />
@@ -1636,6 +1646,10 @@
       </inputs>
     </hardware>
     <roms>
+      <patches>
+        <!-- Prevent "rolling start" scrolling glitch -->
+        <patch region="crom" bits="32" offset="0x14E3F0" value="0x20B201E0" />
+      </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-20095a.20" crc32="0x58C7E393" />
         <file offset="2" name="epr-20094a.19" crc32="0xDBF17A43" />
@@ -1684,6 +1698,10 @@
       </inputs>
     </hardware>
     <roms>
+      <patches>
+        <!-- Prevent "rolling start" scrolling glitch -->
+        <patch region="crom" bits="32" offset="0x14E014" value="0x20B201E0" />
+      </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-20095.20" crc32="0x44467BC1" />
         <file offset="2" name="epr-20094.19" crc32="0x299B6257" />


### PR DESCRIPTION
In Scud Race there is a glitch involving the "ROLLING START" banner. The tilemap layer that contains the banner is layer A' and it is scrolled left by 8 pixels every frame, and after exiting the left side of the screen it wraps back around to the right. Because the wraparound occurs every 512 pixels and the banner is 480 pixels long, a mask is used to hide every other appearance of the banner.

The glitch is that every four frames, the eight leftmost pixels of the banner that should be invisible manage to peek though and become visible; after much debugging I have determined that the glitch is due to the developers making the layer A' mask slightly too long on the right hand side. There seems to be some tilegen quirk that causes this glitch not to happen on real hardware, but we can't be 100% sure what it is without testing.

Rather than rewrite the tilegen code to try and replicate a quirk that we're not even sure how to reproduce, I decided it would be much easier to just patch all of the Scud ROM sets to shorten the layer A' mask and stop the glitch from occurring.