### PR TITLE
Ping-pong flip timing depends of the value of tilegen register 0x08

### DIFF
--- a/Src/Debugger/ConsoleDebugger.cpp
+++ b/Src/Debugger/ConsoleDebugger.cpp
@@ -40,7 +40,7 @@ namespace Debugger
 	CConsoleDebugger::CConsoleDebugger() : CDebugger(), 
 		m_nextFrame(false), m_listDism(0), m_listMem(0), m_analyseCode(true), 
 		m_addrFmt(HexDollar), m_portFmt(Decimal), m_dataFmt(HexDollar),
-		m_showLabels(true), m_labelsOverAddr(true), m_showOpCodes(false), m_memBytesPerRow(12), m_file(NULL)
+		m_showLabels(true), m_labelsOverAddr(true), m_showOpCodes(false), m_memBytesPerRow(16), m_file(NULL)
 	{
 		//
 	}

--- a/Src/Debugger/SupermodelDebugger.cpp
+++ b/Src/Debugger/SupermodelDebugger.cpp
@@ -62,8 +62,8 @@ namespace Debugger
 		// Interrupts
 		cpu->AddInterrupt("VD0", 0, "Unknown video-related");
 		cpu->AddInterrupt("VBL", 1, "VBlank start");
-		cpu->AddInterrupt("VD2", 2, "Unknown video-related");
-		cpu->AddInterrupt("VD3", 3, "Unknown video-related");
+		cpu->AddInterrupt("VDP", 2, "DP done (display processing)");
+		cpu->AddInterrupt("VGP", 3, "GP done (geometry processing)");
 		cpu->AddInterrupt("NET", 4, "Network");
 		cpu->AddInterrupt("UN5", 5, "Unknown");
 		cpu->AddInterrupt("SND", 6, "SCSP (sound)");
@@ -82,8 +82,8 @@ namespace Debugger
 		cpu->AddRegion(0xC0000000, 0xC00000FF, false, false, "SCSI (Step 1.x)");
 #endif
 #ifdef NET_BOARD
-		cpu->AddRegion(0xC0000000, 0xC001FFFF, false, false, "Network Buffer");
-		cpu->AddRegion(0xC0020000, 0xC003FFFF, false, false, "Network RAM");
+		cpu->AddRegion(0xC0000000, 0xC000FFFF, false, false, "Netboard Shared RAM (Step 1.5+)");
+		cpu->AddRegion(0xC0020000, 0xC002FFFF, false, false, "Netboard Program RAM (Step 1.5+)");
 #endif
 		cpu->AddRegion(0xC1000000, 0xC10000FF, false, false, "SCSI (Step 1.x) (Lost World expects it here)");
 		cpu->AddRegion(0xC2000000, 0xC20000FF, false, false, "Real3D DMA (Step 2.x)");
@@ -91,7 +91,7 @@ namespace Debugger
 		cpu->AddRegion(0xF0080000, 0xF0080007, false, false, "Sound Board Registers");
 		cpu->AddRegion(0xF00C0000, 0xF00DFFFF, false, false, "Backup RAM");
 		cpu->AddRegion(0xF0100000, 0xF010003F, false, false, "System Registers");
-		cpu->AddRegion(0xF0140000, 0xF014003F, false, false, "Real, 0xTime Clock");
+		cpu->AddRegion(0xF0140000, 0xF014003F, false, false, "Real-Time Clock");
 		cpu->AddRegion(0xF0180000, 0xF019FFFF, false, false, "Security Board RAM");
 		cpu->AddRegion(0xF01A0000, 0xF01A003F, false, false, "Security Board Registers");
 		cpu->AddRegion(0xF0800CF8, 0xF0800CFF, false, false, "MPC105 CONFIG_cpu->AddR (Step 1.x)");
@@ -103,6 +103,7 @@ namespace Debugger
 		cpu->AddRegion(0xF8FFF000, 0xF8FFF0FF, false, false, "MPC105 (Step 1.x) or MPC106 (Step 2.x) Registers");
 		cpu->AddRegion(0xF9000000, 0xF90000FF, false, false, "NCR 53C810 Registers (Step 1.x?)");
 		cpu->AddRegion(0xFE040000, 0xFE04003F, false, false, "Mirrored Input Registers");
+		cpu->AddRegion(0xFE100000, 0xFE10003F, false, false, "Mirrored System Registers");
 		cpu->AddRegion(0xFEC00000, 0xFEDFFFFF, false, false, "MPC106 CONFIG_cpu->AddR (Step 2.x)");
 		cpu->AddRegion(0xFEE00000, 0xFEFFFFFF, false, false, "MPC106 CONFIG_DATA (Step 2.x)");
 		cpu->AddRegion(0xFF000000, 0xFF7FFFFF, true,  true,  "Banked CROM (CROMxx)");

--- a/Src/Model3/Model3.cpp
+++ b/Src/Model3/Model3.cpp
@@ -2048,15 +2048,15 @@ void CModel3::RunMainBoardFrame(void)
 	// Compute display timings
 	unsigned ppcCycles		= m_config["PowerPCFrequency"].ValueAs<unsigned>() * 1000000;
 	unsigned frameCycles	= (unsigned)((float)ppcCycles / 57.524160f);
-    unsigned lineCycles     = frameCycles / 424;
-    unsigned dispCycles     = lineCycles * (TileGen.ReadRegister(0x08) + 40);
-    unsigned offsetCycles   = frameCycles - dispCycles;
+	unsigned lineCycles     = frameCycles / 424;
+	unsigned dispCycles     = lineCycles * (TileGen.ReadRegister(0x08) + 40);
+	unsigned offsetCycles   = frameCycles - dispCycles;
 	unsigned statusCycles   = (unsigned)((float)frameCycles * (0.005f));
 
 	// Games will start writing a new frame after the ping-pong buffers have been flipped, which is indicated by the
-    // ping-pong status bit. The timing of ping-pong flip is determined by the value of tilegen register 0x08, which
-    // is the number of active video lines to display before ping-pong flip occurs. Most games set it to 238 or 239
-    // so that ping-pong flip occurs 66% of the frame time after IRQ2, though a few games set it to a higher value.
+	// ping-pong status bit. The timing of ping-pong flip is determined by the value of tilegen register 0x08, which
+	// is the number of active video lines to display before ping-pong flip occurs. Most games set it to 238 or 239
+	// so that ping-pong flip occurs 66% of the frame time after IRQ2, though a few games set it to a higher value.
 
 	// Scale PPC timer ratio according to speed at which the PowerPC is being emulated so that the observed running frequency of the PPC timer
 	// registers is more or less correct.  This is needed to get the Virtua Striker 2 series of games running at the right speed (they are


### PR DESCRIPTION
Also make the debugger display 16 bytes per line when using the "listmemory" command. Mirrored system registers can now be watched.

At some point I'd like to reimplement the RunMainBoardFrame() function but this will do for now.