### PR TITLE
fixed `-Wformat-overflow` compiler warnings / added missing newline to log messages

### DIFF
--- a/Src/Debugger/CPU/68KDebug.cpp
+++ b/Src/Debugger/CPU/68KDebug.cpp
@@ -1244,7 +1244,7 @@ namespace Debugger
 		int offset = 2;
 
 		const char *instr;
-		char moveStr[50];
+		char moveStr[64];
 		char dataStr[20];
 		INT8 i8;
 		INT16 i16;

--- a/Src/OSD/Logger.cpp
+++ b/Src/OSD/Logger.cpp
@@ -239,8 +239,8 @@ void CFileLogger::DebugLog(const char *fmt, va_list vl)
   char string1[4096];
   char string2[4096];
 
-  vsprintf(string1, fmt, vl);
-  sprintf(string2, "[Debug] %s", string1);
+  vsnprintf(string1, sizeof(string1), fmt, vl);
+  snprintf(string2, sizeof(string2), "[Debug] %s", string1);
 
   // Debug logging is so copious that we don't bother to guarantee it is saved
   std::unique_lock<std::mutex> lock(m_mtx);
@@ -257,8 +257,8 @@ void CFileLogger::InfoLog(const char *fmt, va_list vl)
   char string1[4096];
   char string2[4096];
 
-  vsprintf(string1, fmt, vl);
-  sprintf(string2, "[Info]  %s\n", string1);
+  vsnprintf(string1, sizeof(string1), fmt, vl);
+  snprintf(string2, sizeof(string2), "[Info]  %s\n", string1);
 
   // Write to file, close, and reopen to ensure it was saved
   std::unique_lock<std::mutex> lock(m_mtx);
@@ -276,8 +276,8 @@ void CFileLogger::ErrorLog(const char *fmt, va_list vl)
   char string1[4096];
   char string2[4096];
 
-  vsprintf(string1, fmt, vl);
-  sprintf(string2, "[Error] %s\n", string1);
+  vsnprintf(string1, sizeof(string1), fmt, vl);
+  snprintf(string2, sizeof(string2), "[Error] %s\n", string1);
 
   // Write to file, close, and reopen to ensure it was saved
   std::unique_lock<std::mutex> lock(m_mtx);
@@ -347,8 +347,8 @@ void CSystemLogger::DebugLog(const char *fmt, va_list vl)
   char string1[4096];
   char string2[4096];
 
-  vsprintf(string1, fmt, vl);
-  sprintf(string2, "[Debug] %s", string1);
+  vsnprintf(string1, sizeof(string1), fmt, vl);
+  snprintf(string2, sizeof(string2), "[Debug] %s", string1);
 
 #ifdef _WIN32
   OutputDebugString(string2);
@@ -367,8 +367,8 @@ void CSystemLogger::InfoLog(const char *fmt, va_list vl)
   char string1[4096];
   char string2[4096];
 
-  vsprintf(string1, fmt, vl);
-  sprintf(string2, "[Info]  %s\n", string1);
+  vsnprintf(string1, sizeof(string1), fmt, vl);
+  snprintf(string2, sizeof(string2), "[Info]  %s\n", string1);
 
 #ifdef _WIN32
   OutputDebugString(string2);
@@ -387,8 +387,8 @@ void CSystemLogger::ErrorLog(const char *fmt, va_list vl)
   char string1[4096];
   char string2[4096];
 
-  vsprintf(string1, fmt, vl);
-  sprintf(string2, "[Error] %s\n", string1);
+  vsnprintf(string1, sizeof(string1), fmt, vl);
+  snprintf(string2, sizeof(string2), "[Error] %s\n", string1);
 
  #ifdef _WIN32
   OutputDebugString(string2);

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -919,7 +919,7 @@ int Supermodel(const Game &game, ROMSet *rom_set, IEmulator *Model3, CInputs *In
 
   // Set the video mode
   char baseTitleStr[128];
-  char titleStr[128];
+  char titleStr[256];
   totalXRes = xRes = s_runtime_config["XResolution"].ValueAs<unsigned>();
   totalYRes = yRes = s_runtime_config["YResolution"].ValueAs<unsigned>();
   sprintf(baseTitleStr, "Supermodel - %s", game.title.c_str());
@@ -1089,7 +1089,7 @@ int Supermodel(const Game &game, ROMSet *rom_set, IEmulator *Model3, CInputs *In
       {
         Model3->PauseThreads();
         SetAudioEnabled(false);
-        sprintf(titleStr, "%s (Paused)", baseTitleStr);
+        snprintf(titleStr, sizeof(titleStr), "%s (Paused)", baseTitleStr);
         SDL_SetWindowTitle(s_window, titleStr);
       }
       else
@@ -1303,7 +1303,7 @@ int Supermodel(const Game &game, ROMSet *rom_set, IEmulator *Model3, CInputs *In
       if (measurementTicks >= s_perfCounterFrequency) // update FPS every 1 second (s_perfCounterFrequency is how many perf ticks in one second)
       {
         float fps = float(fpsFramesElapsed) / (float(measurementTicks) / float(s_perfCounterFrequency));
-        sprintf(titleStr, "%s - %1.3f FPS%s", baseTitleStr, fps, paused ? " (Paused)" : "");
+        snprintf(titleStr, sizeof(titleStr), "%s - %1.3f FPS%s", baseTitleStr, fps, paused ? " (Paused)" : "");
         SDL_SetWindowTitle(s_window, titleStr);
         prevFPSTicks = currentFPSTicks;   // reset tick count
         fpsFramesElapsed = 0;             // reset frame count


### PR DESCRIPTION
Some examples for reference:
```
Src/OSD/SDL/Main.cpp:1086:30: warning: ‘ (Paused)’ directive writing 9 bytes into a region of size between 1 and 128 [-Wformat-overflow=]
 1086 |         sprintf(titleStr, "%s (Paused)", baseTitleStr);
      |                              ^~~~~~~~~
Src/OSD/SDL/Main.cpp:1086:16: note: ‘sprintf’ output between 10 and 137 bytes into a destination of size 128
 1086 |         sprintf(titleStr, "%s (Paused)", baseTitleStr);
      |         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
Src/OSD/Logger.cpp:382:29: warning: ‘%s’ directive writing up to 4095 bytes into a region of size 4088 [-Wformat-overflow=]
  382 |   sprintf(string2, "[Error] %s\n", string1);
      |                             ^~     ~~~~~~~
Src/OSD/Logger.cpp:382:10: note: ‘sprintf’ output between 10 and 4105 bytes into a destination of size 4096
  382 |   sprintf(string2, "[Error] %s\n", string1);
      |   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```