### PR TITLE
Inputs/MultiInputSource.cpp: fixed mismatching allocation and deallocation

### DIFF
--- a/Src/Inputs/MultiInputSource.cpp
+++ b/Src/Inputs/MultiInputSource.cpp
@@ -84,7 +84,7 @@ CMultiInputSource::CMultiInputSource(bool isOr, vector<CInputSource*> &sources) 
 CMultiInputSource::~CMultiInputSource()
 {
 	if (m_srcArray != NULL)
-		delete m_srcArray;
+		delete [] m_srcArray;
 }
 
 void CMultiInputSource::Acquire()


### PR DESCRIPTION
Detected by Cppcheck:
```
Src/Inputs/MultiInputSource.cpp:87:3: error: Mismatching allocation and deallocation: CMultiInputSource::m_srcArray [mismatchAllocDealloc]
  delete m_srcArray;
  ^
```