### PR TITLE
Model3.cpp: avoid usage of uninitialized memory

### DIFF
--- a/Src/Model3/Model3.cpp
+++ b/Src/Model3/Model3.cpp
@@ -3205,6 +3205,7 @@ CModel3::CModel3(Util::Config::Node &config)
   : m_config(config),
     m_multiThreaded(config["MultiThreaded"].ValueAs<bool>()),
     m_gpuMultiThreaded(config["GPUMultiThreaded"].ValueAs<bool>()),
+    sndBrdWakeNotify(false),
     TileGen(config),
     GPU(config),
     SoundBoard(config),


### PR DESCRIPTION
```
==213531== Thread 20 SoundBoardNoSyn:
==213531== Conditional jump or move depends on uninitialised value(s)
==213531==    at 0x1A1D1E: CModel3::RunSoundBoardThread() (Model3.cpp:2607)
==213531==    by 0x49BECEA: UnknownInlinedFun (SDL_thread.c:292)
==213531==    by 0x49BECEA: RunThread.lto_priv.0 (SDL_systhread.c:76)
==213531==    by 0x4F719EA: start_thread (pthread_create.c:444)
==213531==    by 0x4FF5653: clone (clone.S:100)
```

Happens when e.g. starting `daytona2`.