### PR TITLE
Fixed Scud Race Plus "ROLLING START" patch

### DIFF
--- a/Config/Games.xml
+++ b/Config/Games.xml
@@ -1643,7 +1643,7 @@
     <roms>
       <patches>
         <!-- Prevent "rolling start" scrolling glitch -->
-        <patch region="crom" bits="32" offset="0x14E3F0" value="0x20B201E0" />
+        <patch region="crom" bits="32" offset="0x14E424" value="0x20B201E0" />
       </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-20095a.20" crc32="0x58C7E393" />


### PR DESCRIPTION
Accidentally patched the wrong memory location in Scud Race Plus