### PR TITLE
fix segfault in CMultiLogger

### DIFF
--- a/Src/OSD/Logger.cpp
+++ b/Src/OSD/Logger.cpp
@@ -168,7 +168,10 @@ void CMultiLogger::DebugLog(const char *fmt, va_list vl)
 {
   for (auto &logger: m_loggers)
   {
-    logger->DebugLog(fmt, vl);
+    va_list vl_tmp;
+    va_copy(vl_tmp, vl);
+    logger->DebugLog(fmt, vl_tmp);
+    va_end(vl_tmp);
   }
 }
 
@@ -176,7 +179,10 @@ void CMultiLogger::InfoLog(const char *fmt, va_list vl)
 {
   for (auto &logger: m_loggers)
   {
-    logger->InfoLog(fmt, vl);
+    va_list vl_tmp;
+    va_copy(vl_tmp, vl);
+    logger->InfoLog(fmt, vl_tmp);
+    va_end(vl_tmp);
   }
 }
 
@@ -184,7 +190,10 @@ void CMultiLogger::ErrorLog(const char *fmt, va_list vl)
 {
   for (auto &logger: m_loggers)
   {
-    logger->ErrorLog(fmt, vl);
+    va_list vl_tmp;
+    va_copy(vl_tmp, vl);
+    logger->ErrorLog(fmt, vl_tmp);
+    va_end(vl_tmp);
   }
 }
 


### PR DESCRIPTION
Tested on linux with glibc.

A segfault can be triggered when Supermodel does not find a Supermodel.ini file to load. At that point it will call CConsoleErrorLogger::ErrorLog and then CFileLogger::ErrorLog.

The reason for the segfault is that vsprintf may change its va_list argument so repeatedly calling it with the same va_list arg is undefined behavior.

Fix this by creating a copy of the va_list argument before each vsprintf call.