### PR TITLE
Fix 2D texture rendering on OSX

### DIFF
--- a/Src/Graphics/Shaders2D.h
+++ b/Src/Graphics/Shaders2D.h
@@ -188,12 +188,12 @@ static const char s_fragmentShaderTileGen[] = R"glsl(
 	}
 
 	// register data
-	bool LineScrollMode		(int layerNum)	{ return (regs[0x60/4 + layerNum] & 0x8000) != 0; }
-	int  GetHorizontalScroll(int layerNum)	{ return int(regs[0x60 / 4 + layerNum] &0x3FFu); }
+	bool LineScrollMode		(int layerNum)	{ return (regs[0x60/4 + layerNum] & 0x8000u) != 0; }
+	int  GetHorizontalScroll(int layerNum)	{ return int(regs[0x60/4 + layerNum] & 0x3FFu); }
 	int  GetVerticalScroll	(int layerNum)	{ return int((regs[0x60/4 + layerNum] >> 16) & 0x1FFu); }
 	int	 LayerPriority		()				{ return int((regs[0x20/4] >> 8) & 0xFu); }
-    bool LayerIs4Bit		(int layerNum)	{ return (regs[0x20/4] & (1 << (12 + layerNum))) != 0; }
-    bool LayerEnabled		(int layerNum)	{ return (regs[0x60/4 + layerNum] & 0x80000000) != 0; }
+    bool LayerIs4Bit		(int layerNum)	{ return (regs[0x20/4] & uint(1 << (12 + layerNum))) != 0; }
+    bool LayerEnabled		(int layerNum)	{ return (regs[0x60/4 + layerNum] & 0x80000000u) != 0; }
     bool LayerSelected		(int layerNum)	{ return (LayerPriority() & (1 << layerNum)) == 0; }
 
 	float Int8ToFloat(uint c)
@@ -225,11 +225,12 @@ static const char s_fragmentShaderTileGen[] = R"glsl(
 		uint alpha = (colour>>15);		// top bit is alpha. 1 means clear, 0 opaque
 		alpha = ~alpha;					// invert
 		alpha = alpha & 0x1u;			// mask bit
+		const uint mask = 0x1F;
 		
 		vec4 c;
-		c.r = float((colour >> 0 ) & 0x1F) / 31.0;
-		c.g = float((colour >> 5 ) & 0x1F) / 31.0;
-		c.b = float((colour >> 10) & 0x1F) / 31.0;
+		c.r = float((colour >> 0 ) & mask) / 31.0;
+		c.g = float((colour >> 5 ) & mask) / 31.0;
+		c.b = float((colour >> 10) & mask) / 31.0;
 		c.a = float(alpha) / 1.0;
 
 		c.rgb *= c.a;		// multiply by alpha value, this will push transparent to black, no branch needed

--- a/Src/Graphics/Shaders2D.h
+++ b/Src/Graphics/Shaders2D.h
@@ -189,12 +189,12 @@ static const char s_fragmentShaderTileGen[] = R"glsl(
 
 	// register data
 	bool LineScrollMode		(int layerNum)	{ return (regs[0x60/4 + layerNum] & 0x8000u) != 0; }
-	int  GetHorizontalScroll(int layerNum)	{ return int(regs[0x60/4 + layerNum] & 0x3FFu); }
-	int  GetVerticalScroll	(int layerNum)	{ return int((regs[0x60/4 + layerNum] >> 16) & 0x1FFu); }
-	int	 LayerPriority		()				{ return int((regs[0x20/4] >> 8) & 0xFu); }
-    bool LayerIs4Bit		(int layerNum)	{ return (regs[0x20/4] & uint(1 << (12 + layerNum))) != 0; }
-    bool LayerEnabled		(int layerNum)	{ return (regs[0x60/4 + layerNum] & 0x80000000u) != 0; }
-    bool LayerSelected		(int layerNum)	{ return (LayerPriority() & (1 << layerNum)) == 0; }
+	int  GetHorizontalScroll	(int layerNum)	{ return int(regs[0x60/4 + layerNum] & 0x3FFu); }
+	int  GetVerticalScroll		(int layerNum)	{ return int((regs[0x60/4 + layerNum] >> 16) & 0x1FFu); }
+	int  LayerPriority		()		{ return int((regs[0x20/4] >> 8) & 0xFu); }
+	bool LayerIs4Bit		(int layerNum)	{ return (regs[0x20/4] & uint(1 << (12 + layerNum))) != 0; }
+	bool LayerEnabled		(int layerNum)	{ return (regs[0x60/4 + layerNum] & 0x80000000u) != 0; }
+	bool LayerSelected		(int layerNum)	{ return (LayerPriority() & (1 << layerNum)) == 0; }
 
 	float Int8ToFloat(uint c)
 	{


### PR DESCRIPTION
2D textures no longer render after c6ea81d due to shader error on OSX.
I don't think this is an OSX specific issue, but that's the platform I noticed it on.

Before patch:
```
Supermodel: A Sega Model 3 Arcade Emulator (Version 0.3a-git-1bb7de1)
Copyright 2003-2023 by The Supermodel Team
GPU info: 4.1 Metal - 88 (core profile)

    Title:          Daytona USA 2 - Power Edition (Japan)
    ROM Set:        dayto2pe
    Developer:      Sega
    Year:           1998
    Stepping:       2.1
    Extra Hardware: Digital Sound Board (Type DSB2), Drive Board, Net Board, Security Board

ERROR: 0:86: '&' does not operate on 'unsigned int' and 'int'
ERROR: 0:90: '&' does not operate on 'unsigned int' and 'int'
ERROR: 0:91: '&' does not operate on 'unsigned int' and 'int'
ERROR: 0:125: '&' does not operate on 'unsigned int' and 'int'
ERROR: 0:126: '&' does not operate on 'unsigned int' and 'int'
ERROR: 0:127: '&' does not operate on 'unsigned int' and 'int'

ERROR: One or more attached shaders not successfully compiled
```