### PR TITLE
support engine selection with print-gl-info argument

### DIFF
--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -378,7 +378,7 @@ static void PrintGLInfo(bool createScreen, bool infoLog, bool printExtensions)
   unsigned xOffset, yOffset, xRes=496, yRes=384, totalXRes, totalYRes;
   if (createScreen)
   {
-    if (OKAY != CreateGLScreen(false, false, "Supermodel - Querying OpenGL Information...", false, &xOffset, &yOffset, &xRes, &yRes, &totalXRes, &totalYRes, false, false))
+    if (OKAY != CreateGLScreen(s_runtime_config["New3DEngine"].ValueAs<bool>(), s_runtime_config["QuadRendering"].ValueAs<bool>(), "Supermodel - Querying OpenGL Information...", false, &xOffset, &yOffset, &xRes, &yRes, &totalXRes, &totalYRes, false, false))
     {
       ErrorLog("Unable to query OpenGL.\n");
       return;
@@ -1938,6 +1938,7 @@ int main(int argc, char **argv)
   }
   if (cmd_line.print_gl_info)
   {
+    Util::Config::MergeINISections(&s_runtime_config, DefaultConfig(), cmd_line.config);
     // We must exit after this because CreateGLScreen() is used
     PrintGLInfo(true, false, false);
     return 0;


### PR DESCRIPTION
print-gl-info always defaults to legacy, which on mac at least, returns unexpected info.
with this PR the default engine is now new3d, or whatever is globally configured.

Before (only lines that changed):

```
GPU info: 2.1 Metal - 88
  Version                  : 2.1 Metal - 88
  Shading Language Version : 1.20
```

After

```
GPU info: 4.1 Metal - 88 (core profile)
  Version                  : 4.1 Metal - 88
  Shading Language Version : 4.10
```

Also supports specifying the engine and printing info, eg `supermodel -legacy3d -print-gl-info`