### PR TITLE
Adding newly dumped version of Scud Race

### DIFF
--- a/Config/Games.xml
+++ b/Config/Games.xml
@@ -1554,7 +1554,7 @@
       <stepping>1.5</stepping>
       <mpeg_board>DSB1</mpeg_board>
       <drive_board>Wheel</drive_board>
-      <netboard>true</netboard>
+      <netboard>false</netboard>
       <audio>QuadFrontRear</audio>
       <inputs>
         <input type="common" />
@@ -1611,6 +1611,79 @@
       </region>
       <region name="sound_program" stride="1" chunk_size="1" byte_swap="true">
         <file offset="0" name="epr-19611a.21" crc32="0x9D4A34F6" />
+      </region>
+      <region name="sound_samples" stride="1" chunk_size="1" byte_swap="true">
+        <file offset="0x000000" name="mpr-19601.22" crc32="0xBA350FCC" />
+        <file offset="0x400000" name="mpr-19602.24" crc32="0xA92231C1" />
+      </region>
+    </roms>
+  </game>
+  
+  <game name="scuddxo" parent="scud">
+    <identity>
+      <title>Scud Race</title>
+      <version>Export, Deluxe</version>
+      <manufacturer>Sega</manufacturer>
+      <year>1996</year>
+    </identity>
+    <hardware>
+      <platform>Sega Model 3</platform>
+      <stepping>1.5</stepping>
+      <mpeg_board>DSB1</mpeg_board>
+      <drive_board>Wheel</drive_board>
+	  <netboard>false</netboard>
+      <audio>QuadFrontRear</audio>
+      <inputs>
+        <input type="common" />
+        <input type="vehicle" />
+        <input type="shift4" />
+        <input type="vr4" />
+      </inputs>
+    </hardware>
+    <roms>
+      <region name="crom" stride="8" chunk_size="2" byte_swap="true">
+        <file offset="0" name="epr-19607.20" crc32="0x365CE059" />
+        <file offset="2" name="epr-19608.19" crc32="0x56B46D26" />
+        <file offset="4" name="epr-19609.18" crc32="0x75D2675C" />
+        <file offset="6" name="epr-19610.17" crc32="0x3632870A" />
+      </region>
+      <region name="banked_crom" stride="8" chunk_size="2" byte_swap="true">
+        <!-- CROM0 -->
+        <file offset="0x0000000" name="mpr-19589.4" crc32="0x5482238F" />
+        <file offset="0x0000002" name="mpr-19590.3" crc32="0xA5CD4718" />
+        <file offset="0x0000004" name="mpr-19591.2" crc32="0x48E1AAFF" />
+        <file offset="0x0000006" name="mpr-19592.1" crc32="0xD9003B6F" />
+        <!-- CROM1 -->
+        <file offset="0x1000000" name="mpr-19593.8" crc32="0x21E48FF8" />
+        <file offset="0x1000002" name="mpr-19594.7" crc32="0x654C26B0" />
+        <file offset="0x1000004" name="mpr-19595.6" crc32="0xD06FD9D6" />
+        <file offset="0x1000006" name="mpr-19596.5" crc32="0x5672E3F4" />
+        <!-- CROM2 -->
+        <file offset="0x2000000" name="mpr-19597.12" crc32="0x4D0FFE60" />
+        <file offset="0x2000002" name="mpr-19598.11" crc32="0xA081592E" />
+        <file offset="0x2000004" name="mpr-19599.10" crc32="0x65C1D33C" />
+        <file offset="0x2000006" name="mpr-19600.9" crc32="0xA25DA127" />
+      </region>
+      <region name="vrom" stride="32" chunk_size="2">
+        <file offset="0"  name="mpr-19574.26" crc32="0x9BE8F314" />
+        <file offset="2"  name="mpr-19573.27" crc32="0x57B61D65" />
+        <file offset="4"  name="mpr-19576.28" crc32="0x85F9B587" />
+        <file offset="6"  name="mpr-19575.29" crc32="0xDAB11C34" />
+        <file offset="8"  name="mpr-19578.30" crc32="0xAE882C42" />
+        <file offset="10" name="mpr-19577.31" crc32="0x36A1FE5D" />
+        <file offset="12" name="mpr-19580.32" crc32="0x62503CEE" />
+        <file offset="14" name="mpr-19579.33" crc32="0xAF9698D0" />
+        <file offset="16" name="mpr-19582.34" crc32="0xC8B9CF1A" />
+        <file offset="18" name="mpr-19581.35" crc32="0x8863C2D7" />
+        <file offset="20" name="mpr-19584.36" crc32="0x256B056C" />
+        <file offset="22" name="mpr-19583.37" crc32="0xC22CB5AA" />
+        <file offset="24" name="mpr-19586.38" crc32="0xAC37163E" />
+        <file offset="26" name="mpr-19585.39" crc32="0xE2598012" />
+        <file offset="28" name="mpr-19588.40" crc32="0x42E20AE9" />
+        <file offset="30" name="mpr-19587.41" crc32="0xC288C910" />
+      </region>
+      <region name="sound_program" stride="1" chunk_size="1" byte_swap="true">
+        <file offset="0" name="epr-19611.21" crc32="0x8888BF36" />
       </region>
       <region name="sound_samples" stride="1" chunk_size="1" byte_swap="true">
         <file offset="0x000000" name="mpr-19601.22" crc32="0xBA350FCC" />

--- a/Src/Model3/Model3.cpp
+++ b/Src/Model3/Model3.cpp
@@ -1015,9 +1015,9 @@ UINT8 CModel3::Read8(UINT32 addr)
     break;
 
   // 53C810 SCSI
-  case 0xC0:  // only on Step 1.0
+  case 0xC0:  // only on Step 1.x
 #ifndef NET_BOARD
-    if (m_game.stepping != "1.0")
+    if (m_game.stepping != "1.0" && m_game.stepping != "1.5")
     {
       //printf("Model3 : Read8 %x\n", addr);
       break;
@@ -1049,7 +1049,7 @@ UINT8 CModel3::Read8(UINT32 addr)
       break;
     }
   }
-  else if (m_game.stepping != "1.0") break;
+  else if (m_game.stepping != "1.0" && m_game.stepping != "1.5") break;
 #endif
   case 0xF9:
   case 0xC1:
@@ -1309,9 +1309,9 @@ UINT32 CModel3::Read32(UINT32 addr)
     break;
 
   // 53C810 SCSI
-  case 0xC0:  // only on Step 1.0
+  case 0xC0:  // only on Step 1.x
 #ifndef NET_BOARD
-    if (m_game.stepping != "1.0") // check for Step 1.0
+    if (m_game.stepping != "1.0" && m_game.stepping != "1.5") // check for Step 1.x
       break;
 #endif
 #ifdef NET_BOARD
@@ -1346,7 +1346,7 @@ UINT32 CModel3::Read32(UINT32 addr)
       }
 
     }
-    else if (m_game.stepping != "1.0") break;
+    else if (m_game.stepping != "1.0" && m_game.stepping != "1.5") break;
 #endif
   case 0xF9:
   case 0xC1:
@@ -1466,9 +1466,9 @@ void CModel3::Write8(UINT32 addr, UINT8 data)
     break;
 
   // 53C810 SCSI
-  case 0xC0:  // only on Step 1.0
+  case 0xC0:  // only on Step 1.x
 #ifndef NET_BOARD
-    if (m_game.stepping != "1.0")
+    if (m_game.stepping != "1.0" && m_game.stepping != "1.5")
       goto Unknown8;
 #endif
 #ifdef NET_BOARD
@@ -1503,7 +1503,7 @@ void CModel3::Write8(UINT32 addr, UINT8 data)
 
       break;
     }
-    else if (m_game.stepping != "1.0") break;
+    else if (m_game.stepping != "1.0" && m_game.stepping != "1.5") break;
 #endif
   case 0xF9:
   case 0xC1:
@@ -1788,9 +1788,9 @@ void CModel3::Write32(UINT32 addr, UINT32 data)
     break;
 
   // 53C810 SCSI
-  case 0xC0:  // step 1.0 only
+  case 0xC0:  // step 1.x only
 #ifndef NET_BOARD
-    if (m_game.stepping != "1.0")
+    if (m_game.stepping != "1.0" && m_game.stepping != "1.5")
       goto Unknown32;
 #endif
 #ifdef NET_BOARD
@@ -1825,7 +1825,7 @@ void CModel3::Write32(UINT32 addr, UINT32 data)
 
       break;
     }
-    else if (m_game.stepping != "1.0") break;
+    else if (m_game.stepping != "1.0" && m_game.stepping != "1.5") break;
 #endif
   case 0xF9:
   case 0xC1:

--- a/Src/Model3/Model3.cpp
+++ b/Src/Model3/Model3.cpp
@@ -1017,7 +1017,7 @@ UINT8 CModel3::Read8(UINT32 addr)
   // 53C810 SCSI
   case 0xC0:  // only on Step 1.x
 #ifndef NET_BOARD
-    if (m_game.stepping != "1.0" && m_game.stepping != "1.5")
+    if (m_stepping > 0x15)
     {
       //printf("Model3 : Read8 %x\n", addr);
       break;
@@ -1049,7 +1049,7 @@ UINT8 CModel3::Read8(UINT32 addr)
       break;
     }
   }
-  else if (m_game.stepping != "1.0" && m_game.stepping != "1.5") break;
+  else if (m_stepping > 0x15) break;
 #endif
   case 0xF9:
   case 0xC1:
@@ -1311,7 +1311,7 @@ UINT32 CModel3::Read32(UINT32 addr)
   // 53C810 SCSI
   case 0xC0:  // only on Step 1.x
 #ifndef NET_BOARD
-    if (m_game.stepping != "1.0" && m_game.stepping != "1.5") // check for Step 1.x
+    if (m_stepping > 0x15) // check for Step 1.x
       break;
 #endif
 #ifdef NET_BOARD
@@ -1346,7 +1346,7 @@ UINT32 CModel3::Read32(UINT32 addr)
       }
 
     }
-    else if (m_game.stepping != "1.0" && m_game.stepping != "1.5") break;
+    else if (m_stepping > 0x15) break;
 #endif
   case 0xF9:
   case 0xC1:
@@ -1468,7 +1468,7 @@ void CModel3::Write8(UINT32 addr, UINT8 data)
   // 53C810 SCSI
   case 0xC0:  // only on Step 1.x
 #ifndef NET_BOARD
-    if (m_game.stepping != "1.0" && m_game.stepping != "1.5")
+    if (m_stepping > 0x15)
       goto Unknown8;
 #endif
 #ifdef NET_BOARD
@@ -1503,7 +1503,7 @@ void CModel3::Write8(UINT32 addr, UINT8 data)
 
       break;
     }
-    else if (m_game.stepping != "1.0" && m_game.stepping != "1.5") break;
+    else if (m_stepping > 0x15) break;
 #endif
   case 0xF9:
   case 0xC1:
@@ -1790,7 +1790,7 @@ void CModel3::Write32(UINT32 addr, UINT32 data)
   // 53C810 SCSI
   case 0xC0:  // step 1.x only
 #ifndef NET_BOARD
-    if (m_game.stepping != "1.0" && m_game.stepping != "1.5")
+    if (m_stepping > 0x15)
       goto Unknown32;
 #endif
 #ifdef NET_BOARD
@@ -1825,7 +1825,7 @@ void CModel3::Write32(UINT32 addr, UINT32 data)
 
       break;
     }
-    else if (m_game.stepping != "1.0" && m_game.stepping != "1.5") break;
+    else if (m_stepping > 0x15) break;
 #endif
   case 0xF9:
   case 0xC1:
@@ -2979,8 +2979,8 @@ bool CModel3::LoadGame(const Game &game, const ROMSet &rom_set)
   ppc_set_fetch(PPCFetchRegions);
 
   // Initialize Real3D
-  int stepping = ((game.stepping[0] - '0') << 4) | (game.stepping[2] - '0');
-  GPU.SetStepping(stepping);
+  m_stepping = ((game.stepping[0] - '0') << 4) | (game.stepping[2] - '0');
+  GPU.SetStepping(m_stepping);
 
   // MPEG board (if present)
   if (rom_set.get_rom("mpeg_program").size)

--- a/Src/Model3/Model3.h
+++ b/Src/Model3/Model3.h
@@ -239,6 +239,7 @@ private:
 
   // Game and hardware information
   Game m_game;
+  int m_stepping;
 
   // Game inputs and outputs
   CInputs   *Inputs;


### PR DESCRIPTION
Allow Step 1.5 games to access 53C810 via 0xC00000xx if the netboard is disabled; scuddxo requires this for 3D graphics to work

Also scuddx does not use the netboard