### PR TITLE
Only access SCSI device at 0xC0xxxxxx if it has been configured to do so

### DIFF
--- a/Src/Model3/53C810.cpp
+++ b/Src/Model3/53C810.cpp
@@ -458,6 +458,14 @@ UINT32 C53C810::ReadPCIConfigSpace(unsigned device, unsigned reg, unsigned bits,
 void C53C810::WritePCIConfigSpace(unsigned device, unsigned reg, unsigned bits, unsigned offset, UINT32 data)
 {
   DebugLog("53C810 PCI %d-bit write request for reg=%02X, data=%08X\n", bits, reg, data);
+
+  if (reg == 4) // set base address of SCSI device
+      baseAddress = data & 0xFF;
+}
+
+UINT8 C53C810::GetBaseAddress(void)
+{
+  return baseAddress;
 }
 
 void C53C810::Reset(void)

--- a/Src/Model3/53C810.h
+++ b/Src/Model3/53C810.h
@@ -157,6 +157,13 @@ public:
 	void WritePCIConfigSpace(unsigned device, unsigned reg, unsigned bits, unsigned width, UINT32 data);
 
 	/*
+	 * GetBaseAddress(void):
+	 * 
+	 * Retrieves the base address of the SCSI device.
+	 */
+	UINT8 GetBaseAddress(void);
+
+	/*
 	 * Reset(void):
 	 *
 	 * Resets the device. 
@@ -201,6 +208,9 @@ private:
 	// IRQ controller and IRQ identifier for this SCSI controller
 	CIRQ		*IRQ;
 	unsigned	scsiIRQ;
+
+	// Base address of the SCSI device (varies by game)
+	UINT8	baseAddress;
 };
 
 

--- a/Src/Model3/Model3.cpp
+++ b/Src/Model3/Model3.cpp
@@ -1017,7 +1017,7 @@ UINT8 CModel3::Read8(UINT32 addr)
   // 53C810 SCSI
   case 0xC0:  // only on Step 1.x
 #ifndef NET_BOARD
-    if (m_stepping > 0x15)
+    if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0)
     {
       //printf("Model3 : Read8 %x\n", addr);
       break;
@@ -1049,7 +1049,7 @@ UINT8 CModel3::Read8(UINT32 addr)
       break;
     }
   }
-  else if (m_stepping > 0x15) break;
+  else if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0) break;
 #endif
   case 0xF9:
   case 0xC1:
@@ -1311,7 +1311,7 @@ UINT32 CModel3::Read32(UINT32 addr)
   // 53C810 SCSI
   case 0xC0:  // only on Step 1.x
 #ifndef NET_BOARD
-    if (m_stepping > 0x15) // check for Step 1.x
+    if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0) // check for Step 1.x
       break;
 #endif
 #ifdef NET_BOARD
@@ -1346,7 +1346,7 @@ UINT32 CModel3::Read32(UINT32 addr)
       }
 
     }
-    else if (m_stepping > 0x15) break;
+    else if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0) break;
 #endif
   case 0xF9:
   case 0xC1:
@@ -1468,7 +1468,7 @@ void CModel3::Write8(UINT32 addr, UINT8 data)
   // 53C810 SCSI
   case 0xC0:  // only on Step 1.x
 #ifndef NET_BOARD
-    if (m_stepping > 0x15)
+    if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0)
       goto Unknown8;
 #endif
 #ifdef NET_BOARD
@@ -1503,7 +1503,7 @@ void CModel3::Write8(UINT32 addr, UINT8 data)
 
       break;
     }
-    else if (m_stepping > 0x15) break;
+    else if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0) break;
 #endif
   case 0xF9:
   case 0xC1:
@@ -1790,7 +1790,7 @@ void CModel3::Write32(UINT32 addr, UINT32 data)
   // 53C810 SCSI
   case 0xC0:  // step 1.x only
 #ifndef NET_BOARD
-    if (m_stepping > 0x15)
+    if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0)
       goto Unknown32;
 #endif
 #ifdef NET_BOARD
@@ -1825,7 +1825,7 @@ void CModel3::Write32(UINT32 addr, UINT32 data)
 
       break;
     }
-    else if (m_stepping > 0x15) break;
+    else if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0) break;
 #endif
   case 0xF9:
   case 0xC1:


### PR DESCRIPTION
Last update that added support for newly dumped version of Scud Race (scuddxo) broke some other step 1.5 games.

This update adds a base address member variable to the 53C810 class which must be verified before attempting to access the SCSI device at 0xC0xxxxxx. This removes potential conflicts between SCSI/netboard accesses so all step 1.5 games should be working again.

Hopefully this solution is elegant enough; it's certainly better than adding a game-specific hack for scuddxo.