### PR TITLE
Minor shader optimization

### DIFF
--- a/Src/Graphics/New3D/R3DShaderCommon.h
+++ b/Src/Graphics/New3D/R3DShaderCommon.h
@@ -249,15 +249,22 @@ vec4 textureR3D(usampler2D texSampler, ivec2 wrapMode, ivec2 texSize, ivec2 texP
 	int iLevel = int(fLevel);
 
 	ivec2 texPos0 = GetTexturePosition(iLevel,texPos);
-	ivec2 texPos1 = GetTexturePosition(iLevel+1,texPos);
-
 	ivec2 texSize0 = GetTextureSize(iLevel, texSize);
-	ivec2 texSize1 = GetTextureSize(iLevel+1, texSize); 
 
-	vec4 texLevel0 = texBiLinear(texSampler, wrapMode, vec2(texSize0), texPos0, texCoord);
-	vec4 texLevel1 = texBiLinear(texSampler, wrapMode, vec2(texSize1), texPos1, texCoord);
+	if (fLevel > 0)
+	{
+		ivec2 texPos1 = GetTexturePosition(iLevel+1,texPos);
+		ivec2 texSize1 = GetTextureSize(iLevel+1, texSize); 
 
-	return mix(texLevel0, texLevel1, fract(fLevel));	// linear blend between our mipmap levels
+		vec4 texLevel0 = texBiLinear(texSampler, wrapMode, vec2(texSize0), texPos0, texCoord);
+		vec4 texLevel1 = texBiLinear(texSampler, wrapMode, vec2(texSize1), texPos1, texCoord);
+
+		return mix(texLevel0, texLevel1, fract(fLevel));	// linear blend between our mipmap levels
+	}
+	else
+	{
+		return texBiLinear(texSampler, wrapMode, vec2(texSize0), texPos0, texCoord);
+	}
 }
 
 vec4 GetTextureValue()

--- a/Src/Graphics/New3D/R3DShaderCommon.h
+++ b/Src/Graphics/New3D/R3DShaderCommon.h
@@ -263,6 +263,7 @@ vec4 textureR3D(usampler2D texSampler, ivec2 wrapMode, ivec2 texSize, ivec2 texP
 	}
 	else
 	{
+		// if fLevel is 0, no need to mix with next mipmap level; slight performance boost
 		return texBiLinear(texSampler, wrapMode, vec2(texSize0), texPos0, texCoord);
 	}
 }


### PR DESCRIPTION
Currently the main bottleneck on the GPU side is texture lookup; rather than using texture() to retrieve a single trilinear filtered texel or even two bilinear filtered texels, we are using texelFetch() to retrieve eight separate texels and performing the trilinear filtering ourselves within the shader. This is a lot slower because the texturing unit has to perform eight separate lookups, but it is necessary for accurate results. [(link)](https://supermodel3.com/ArchivedForum/192.168.0.100/Forum/viewtopicbe1f.html?f=7&t=1585&sid=cef2229983e7ae61b43df8e35d27077f)

I was toying about with the shader and I found that performing just bilinear filtering compared to trilinear filtering nearly doubled performance when the emulator was GPU-bound. Then it occurred to me that if we are using the highest quality mipmap only there's no need to perform a trilinear filter; we can perform just a bilinear filter with the highest quality mipmap and the results are identical.

There's almost certainly more that can be done to improve performance further but this was a quick and easy optimization; I got about 10-20% more performance out of Daytona 2, for example.