### PR TITLE
Implementing texture NP values

### DIFF
--- a/Src/Graphics/New3D/Model.h
+++ b/Src/Graphics/New3D/Model.h
@@ -52,6 +52,7 @@ struct R3DPoly
 	Vertex v[4];			// just easier to have them as an array
 	float faceNormal[3];	// we need this to help work out poly winding, i assume the h/w uses this instead of calculating normals itself
 	UINT8 faceColour[4];	// per face colour
+	float textureNP;
 	int number = 4;
 };
 
@@ -59,6 +60,7 @@ struct FVertex : Vertex			// full vertex including face attributes
 {
 	float faceNormal[3];
 	UINT8 faceColour[4];
+	float textureNP;
 
 	FVertex& operator=(const Vertex& vertex) 
 	{
@@ -71,6 +73,7 @@ struct FVertex : Vertex			// full vertex including face attributes
 	{
 		for (int i = 0; i < 4; i++) { faceColour[i] = r3dPoly.faceColour[i]; }
 		for (int i = 0; i < 3; i++) { faceNormal[i] = r3dPoly.faceNormal[i]; }
+		textureNP = r3dPoly.textureNP;
 
 		*this = r3dPoly.v[index];
 	}
@@ -82,6 +85,7 @@ struct FVertex : Vertex			// full vertex including face attributes
 		// copy face attributes
 		for (int i = 0; i < 4; i++) { faceColour[i] = r3dPoly.faceColour[i]; }
 		for (int i = 0; i < 3; i++) { faceNormal[i] = r3dPoly.faceNormal[i]; }
+		textureNP = r3dPoly.textureNP;
 	}
 
 	static void Average(const FVertex& p1, const FVertex& p2, FVertex& p3)
@@ -142,7 +146,7 @@ struct Mesh
 	// microtexture
 	bool	microTexture		= false;
 	int		microTextureID		= 0;
-	float	microTextureScale	= 0;
+	float	microTextureMinLOD	= 0;
 
 	// attributes
 	bool textured		= false;

--- a/Src/Graphics/New3D/New3D.h
+++ b/Src/Graphics/New3D/New3D.h
@@ -244,6 +244,7 @@ private:
 	int		m_step;
 	int		m_offset;			// offset to subtract for words 3 and higher of culling nodes
 	float	m_vertexFactor;		// fixed-point conversion factor for vertices
+	float	m_textureNPFactor;	// fixed-point conversion factor for texture NP values
 
 	// Memory (passed from outside)
 	const UINT32	*m_cullingRAMLo;	// 4 MB

--- a/Src/Graphics/New3D/PolyHeader.cpp
+++ b/Src/Graphics/New3D/PolyHeader.cpp
@@ -306,6 +306,11 @@ int PolyHeader::Y()
 	return y;
 }
 
+float PolyHeader::TextureNP()
+{
+	return (float)(header[5] >> 8);
+}
+
 //
 // header 6
 //

--- a/Src/Graphics/New3D/PolyHeader.h
+++ b/Src/Graphics/New3D/PolyHeader.h
@@ -55,7 +55,7 @@ xxxxxxxx xxxxxxxx xxxxxxxx --------		Color (RGB888 or two 12-bit indexes, sensor
 -------- -------- -------- ---xxxxx		Upper 5 bits of texture U coordinate
 
 0x05 : 
-xxxxxxxx xxxxxxxx xxxxxxxx --------		Texture NP ?
+xxxxxxxx xxxxxxxx xxxxxxxx --------		Texture NP
 -------- -------- -------- x-------		Low bit of texture U coordinate
 -------- -------- -------- ---xxxxx		Low 5 bits of texture V coordinate
 
@@ -115,7 +115,7 @@ public:
 	bool	TexVMirror();
 	bool	MicroTexture();
 	int		MicroTextureID();
-	int		MicroTextureMinLOD();	// basically how many times it repeats compared to the base texture (i assume)
+	int		MicroTextureMinLOD();
 
 	// header 3
 	int		TexWidth();
@@ -133,6 +133,7 @@ public:
 	// header 5
 	int		X();
 	int		Y();
+	float	TextureNP();
 
 	//header 6
 	bool	Layered();

--- a/Src/Graphics/New3D/R3DShader.cpp
+++ b/Src/Graphics/New3D/R3DShader.cpp
@@ -36,7 +36,7 @@ void R3DShader::Start()
 	m_nodeAlpha			= 1.0f;
 	m_shininess			= 0;
 	m_specularValue		= 0;
-	m_microTexScale		= 0;
+	m_microTexMinLOD	= 0;
 	m_microTexID		= -1;
 	m_texturePage		= -1;
 
@@ -108,7 +108,7 @@ bool R3DShader::LoadShader(const char* vertexShader, const char* fragmentShader)
 	m_locTexture2Enabled	= glGetUniformLocation(m_shaderProgram, "microTexture");
 	m_locTextureAlpha		= glGetUniformLocation(m_shaderProgram, "textureAlpha");
 	m_locAlphaTest			= glGetUniformLocation(m_shaderProgram, "alphaTest");
-	m_locMicroTexScale		= glGetUniformLocation(m_shaderProgram, "microTextureScale");
+	m_locMicroTexMinLOD		= glGetUniformLocation(m_shaderProgram, "microTextureMinLOD");
 	m_locMicroTexID			= glGetUniformLocation(m_shaderProgram, "microTextureID");
 	m_locBaseTexInfo		= glGetUniformLocation(m_shaderProgram, "baseTexInfo");
 	m_locBaseTexType		= glGetUniformLocation(m_shaderProgram, "baseTexType");
@@ -224,9 +224,9 @@ void R3DShader::SetMeshUniforms(const Mesh* m)
 		m_texturePage = (m->page ^ m_transPage);
 	}
 
-	if (m_dirtyMesh || m->microTextureScale != m_microTexScale) {
-		glUniform1f(m_locMicroTexScale, m->microTextureScale);
-		m_microTexScale = m->microTextureScale;
+	if (m_dirtyMesh || m->microTextureMinLOD != m_microTexMinLOD) {
+		glUniform1f(m_locMicroTexMinLOD, m->microTextureMinLOD);
+		m_microTexMinLOD = m->microTextureMinLOD;
 	}
 
 	if (m_dirtyMesh || m->microTextureID != m_microTexID) {

--- a/Src/Graphics/New3D/R3DShader.h
+++ b/Src/Graphics/New3D/R3DShader.h
@@ -46,7 +46,7 @@ private:
 	GLint m_locTexturePage;
 	GLint m_locTextureAlpha;
 	GLint m_locAlphaTest;
-	GLint m_locMicroTexScale;
+	GLint m_locMicroTexMinLOD;
 	GLint m_locMicroTexID;
 	GLint m_locBaseTexInfo;
 	GLint m_locBaseTexType;
@@ -73,7 +73,7 @@ private:
 
 	bool	m_layered;
 	bool	m_noLosReturn;
-	float	m_microTexScale;
+	float	m_microTexMinLOD;
 	int		m_microTexID;
 	int		m_baseTexInfo[4];
 	int		m_baseTexType;

--- a/Src/Graphics/New3D/R3DShaderTriangles.h
+++ b/Src/Graphics/New3D/R3DShaderTriangles.h
@@ -19,6 +19,7 @@ in  vec2	inTexCoord;
 in  vec4	inColour;
 in  vec3	inFaceNormal;		// used to emulate r3d culling 
 in  float	inFixedShade;
+in  float	inTextureNP;
 
 // outputs to fragment shader
 out vec3	fsViewVertex;
@@ -27,6 +28,7 @@ out vec2	fsTexCoord;
 out vec4	fsColor;
 out float	fsDiscard;			// can't have varying bool (glsl spec)
 out float	fsFixedShade;
+out float	fsTextureNP;
 
 vec4 GetColour(vec4 colour)
 {
@@ -58,6 +60,7 @@ void main(void)
 	fsColor    		= GetColour(inColour);
 	fsTexCoord		= inTexCoord;
 	fsFixedShade	= inFixedShade;
+	fsTextureNP		= inTextureNP * modelScale;
 	gl_Position		= projMat * modelMat * inVertex;
 }
 )glsl";
@@ -71,7 +74,7 @@ uniform usampler2D textureBank[2];			// entire texture sheet
 // texturing
 uniform bool	textureEnabled;
 uniform bool	microTexture;
-uniform float	microTextureScale;
+uniform float	microTextureMinLOD;
 uniform int		microTextureID;
 uniform ivec4	baseTexInfo;		// x/y are x,y positions in the texture sheet. z/w are with and height
 uniform int		baseTexType;
@@ -115,6 +118,7 @@ in  vec4	fsColor;
 in  vec2	fsTexCoord;
 in  float	fsDiscard;
 in  float	fsFixedShade;
+in	float	fsTextureNP;
 
 //outputs
 layout(location = 0) out vec4 out0;		// opaque


### PR DESCRIPTION
For some reason Model 3 uses vertex coordinates rather than texel coordinates to calculate mipmap levels

Revised microtexture implementation; results are very close to real hardware when running at native resolution with supersampling disabled

Renamed microTextureScale to microTextureMinLOD to better reflect how it is now being used: it directly affects the microtexture blend factor, and it is also used to select the scale factor using a lookup table within the shader