### PR TITLE
Texture mipmaps must be at least 2x2

### DIFF
--- a/Src/Graphics/New3D/R3DShaderCommon.h
+++ b/Src/Graphics/New3D/R3DShaderCommon.h
@@ -210,7 +210,7 @@ vec4 texBiLinear(usampler2D texSampler, ivec2 wrapMode, vec2 texSize, ivec2 texP
 vec4 GetTextureValue()
 {
 	float lod = mip_map_level(fsViewVertex);
-	float numLevels = floor(log2(min(float(baseTexInfo.z), float(baseTexInfo.w))));		// r3d only generates down to 1:1 for square textures, otherwise its the min dimension
+	float numLevels = floor(log2(min(float(baseTexInfo.z), float(baseTexInfo.w)))) - 1.0;	// r3d only generates down to 2:2 for square textures, otherwise its the min dimension
 	float fLevel = clamp(lod, 0.0, numLevels);
 
 	int iLevel = int(fLevel);


### PR DESCRIPTION
My recent texture NP implementation breaks the sky in Dirt Devils as it effectively forces the lowest quality mipmap (1x2). However, if we use the next higher quality mipmap (2x4) the sky is not only fixed, but it finally matches original hardware.

We've always assumed that mipmaps go down to 1x1 (or 2x1, 1x2, etc. for non-square) but it seems that on Model 3 they only go down to 2x2. This sort of makes sense because the texture units read four pixels at a time from four separate CDRAM chips to perform bilinear filtering, and reading a 1x1 texture is a special case that presumably the hardware wasn't built to handle.