### PR TITLE
Give PowerPC more cycles to acknowledge sound IRQs

### DIFF
--- a/Src/Model3/Model3.cpp
+++ b/Src/Model3/Model3.cpp
@@ -2140,8 +2140,8 @@ void CModel3::RunMainBoardFrame(void)
 
 			// Process MIDI interrupt
 			IRQ.Assert(0x40);
-			ppc_execute(400); // give PowerPC time to acknowledge IR
-			dispCycles -= 400;
+			ppc_execute(1000); // give PowerPC time to acknowledge IR
+			dispCycles -= 1000;
 
 			++irqCount;
 			if (irqCount > 128)


### PR DESCRIPTION
400 cycles was not enough and would cause VF3 to hang. 1000 cycles should be more than plenty