### PR TITLE
Scale texture NP values for luminous polygons even if modelScale is not set

### DIFF
--- a/Src/Graphics/New3D/R3DShaderQuads.h
+++ b/Src/Graphics/New3D/R3DShaderQuads.h
@@ -11,6 +11,7 @@ uniform float	nodeAlpha;
 uniform mat4	modelMat;
 uniform mat4	projMat;
 uniform bool	translatorMap;
+uniform bool	lightEnabled;
 
 // attributes
 in vec4		inVertex;
@@ -64,7 +65,7 @@ void main(void)
 	vs_out.color    	= GetColour(inColour);
 	vs_out.texCoord		= inTexCoord;
 	vs_out.fixedShade	= inFixedShade;
-	vs_out.textureNP	= inTextureNP * modelScale;
+	vs_out.textureNP	= inTextureNP * (lightEnabled ? modelScale : modelScale * length(vs_out.viewNormal));
 	gl_Position			= projMat * modelMat * inVertex;
 }
 )glsl";

--- a/Src/Graphics/New3D/R3DShaderTriangles.h
+++ b/Src/Graphics/New3D/R3DShaderTriangles.h
@@ -11,6 +11,7 @@ uniform float	nodeAlpha;
 uniform mat4	modelMat;
 uniform mat4	projMat;
 uniform bool	translatorMap;
+uniform bool	lightEnabled;
 
 // attributes
 in	vec4	inVertex;
@@ -60,7 +61,7 @@ void main(void)
 	fsColor    		= GetColour(inColour);
 	fsTexCoord		= inTexCoord;
 	fsFixedShade	= inFixedShade;
-	fsTextureNP		= inTextureNP * modelScale;
+	fsTextureNP		= inTextureNP * (lightEnabled ? modelScale : modelScale * length(fsViewNormal));
 	gl_Position		= projMat * modelMat * inVertex;
 }
 )glsl";


### PR DESCRIPTION
My implementation of texture NP has resulted in a few cases of scaled up polygons (that are not using the modelScale parameter) using lower-quality mipmaps than they should; these include the lens flare effect in Scud Race and Daytona 2 (possibly also Virtua Striker 2), the fish in Sega Bass Fishing and the map logo and window background in Harley.

All of these cases are luminous polygons, so I've come up with this modification that fixes all of the cases I've managed to find without introducing excessive aliasing to scaled up polygons that currently look fine, e.g. dot matrix display from Expert course in Dirt Devils, Death Star during cutscene in Star Wars Trilogy.