### PR TITLE
First 4MB of VROM maps to polygon RAM

### DIFF
--- a/Src/Model3/Real3D.cpp
+++ b/Src/Model3/Real3D.cpp
@@ -715,7 +715,13 @@ void CReal3D::WriteTexturePort(unsigned reg, uint32_t data)
     {
       uint32_t addr = m_vromTextureFIFO[0];
       uint32_t header = m_vromTextureFIFO[1];
-      UploadTexture(header, (const uint16_t *) &vrom[addr & 0xFFFFFF]);
+
+      // first 4 MB maps to polygon RAM rather than VROM
+      // Daytona 2 PE uses zeroed data to replace unused Dreamcast logo textures
+      if (addr < 0x100000)
+        UploadTexture(header, (const uint16_t*)&polyRAM[addr & 0xFFFFFF]);
+      else
+        UploadTexture(header, (const uint16_t*)&vrom[addr & 0xFFFFFF]);
       m_vromTextureFIFOIdx = 0;
     }
     else


### PR DESCRIPTION
Daytona 2 PE replaces unused Dreamcast logo textures by filling in zeroed data from polygon RAM, making them completely transparent. Before we were reading from the first 4MB of VROM which is filled with 0xFF values, incorrectly resulting in the replaced textures becoming white and opaque.

![image](https://github.com/user-attachments/assets/5826cb3b-ae35-4f93-9fcb-576973629d14)
![image](https://github.com/user-attachments/assets/2676b3ec-6c74-4597-bf54-d288a695a18e)
