### PR TITLE
New textureNP implementation

### DIFF
--- a/Src/Graphics/New3D/Model.h
+++ b/Src/Graphics/New3D/Model.h
@@ -200,6 +200,7 @@ struct Viewport
 	float	angle_right;
 	float	angle_top;
 	float	angle_bottom;
+	float	cota;
 
 	Mat4	projectionMatrix;		// projection matrix, we will calc this later when we have scene near/far vals
 

--- a/Src/Graphics/New3D/New3D.cpp
+++ b/Src/Graphics/New3D/New3D.cpp
@@ -1061,6 +1061,8 @@ void CNew3D::RenderViewport(UINT32 addr)
 		vp->angle_bottom	= -(1.0f - io) / cw;
 		vp->angle_top		= -(0.0f - io) / cw;
 
+		vp->cota = Util::Uint32AsFloat(vpnode[0x3]);
+
 		CalcViewport(vp);
 
 		// Lighting (note that sun vector points toward sun -- away from vertex)

--- a/Src/Graphics/New3D/R3DShader.cpp
+++ b/Src/Graphics/New3D/R3DShader.cpp
@@ -149,6 +149,8 @@ bool R3DShader::LoadShader(const char* vertexShader, const char* fragmentShader)
 	m_locHardwareStep		= glGetUniformLocation(m_shaderProgram, "hardwareStep");
 	m_locDiscardAlpha		= glGetUniformLocation(m_shaderProgram, "discardAlpha");
 
+	m_locCota				= glGetUniformLocation(m_shaderProgram, "cota");
+
 	return true;
 }
 
@@ -362,6 +364,8 @@ void R3DShader::SetViewportUniforms(const Viewport *vp)
 	glUniformMatrix4fv(m_locProjMat, 1, GL_FALSE, vp->projectionMatrix);
 
 	glUniform1i(m_locHardwareStep, vp->hardwareStep);
+
+	glUniform1f(m_locCota, vp->cota);
 }
 
 void R3DShader::SetModelStates(const Model* model)

--- a/Src/Graphics/New3D/R3DShader.h
+++ b/Src/Graphics/New3D/R3DShader.h
@@ -100,6 +100,7 @@ private:
 	GLint m_locFogAttenuation;
 	GLint m_locFogAmbient;
 	GLint m_locProjMat;
+	GLint m_locCota;
 
 	// lighting / other
 	GLint m_locLighting;

--- a/Src/Graphics/New3D/R3DShaderTriangles.h
+++ b/Src/Graphics/New3D/R3DShaderTriangles.h
@@ -8,6 +8,7 @@ static const char *vertexShaderR3D = R"glsl(
 // uniforms
 uniform float	modelScale;
 uniform float	nodeAlpha;
+uniform float	cota;
 uniform mat4	modelMat;
 uniform mat4	projMat;
 uniform bool	translatorMap;
@@ -28,7 +29,7 @@ out vec2	fsTexCoord;
 out vec4	fsColor;
 out float	fsDiscard;			// can't have varying bool (glsl spec)
 out float	fsFixedShade;
-out float	fsTextureNP;
+out float	fsLODBase;
 
 vec4 GetColour(vec4 colour)
 {
@@ -60,7 +61,7 @@ void main(void)
 	fsColor    		= GetColour(inColour);
 	fsTexCoord		= inTexCoord;
 	fsFixedShade	= inFixedShade;
-	fsTextureNP		= inTextureNP * modelScale;
+	fsLODBase		= -fsDiscard * cota * inTextureNP;
 	gl_Position		= projMat * modelMat * inVertex;
 }
 )glsl";
@@ -119,7 +120,7 @@ in  vec4	fsColor;
 in  vec2	fsTexCoord;
 in  float	fsDiscard;
 in  float	fsFixedShade;
-in	float	fsTextureNP;
+in	float	fsLODBase;
 
 //outputs
 layout(location = 0) out vec4 out0;		// opaque


### PR DESCRIPTION
This new implementation uses the previously unused viewport parameter "cota".

At the moment it does not compensate for higher resolutions, partly because doing so would result in microtextures appearing sooner than they should - which would be particularly undesirable for L.A. Machineguns because it has microtextures that aren't even supposed to be there - and most of the textures already look pretty sharp even at 1080p.