### PR TITLE
Fix -print-gl-info after fb785b36bd70c16001336e22a75950ba5ef3808f

### DIFF
--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -278,7 +278,7 @@ static Result CreateGLScreen(bool coreContext, bool quadRendering, const std::st
   SDL_GL_SetAttribute(SDL_GL_RED_SIZE,8);
   SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE,8);
   SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE,8);
-  if(!s_runtime_config.Empty() && s_runtime_config["New3DEngine"].ValueAs<bool>())
+  if(s_runtime_config["New3DEngine"].ValueAsDefault<bool>(true))
   {
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE,0);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE,0);

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -278,7 +278,7 @@ static Result CreateGLScreen(bool coreContext, bool quadRendering, const std::st
   SDL_GL_SetAttribute(SDL_GL_RED_SIZE,8);
   SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE,8);
   SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE,8);
-  if(s_runtime_config["New3DEngine"].ValueAs<bool>())
+  if(!s_runtime_config.Empty() && s_runtime_config["New3DEngine"].ValueAs<bool>())
   {
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE,0);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE,0);


### PR DESCRIPTION
Fixes:

```
Copyright 2003-2024 by The Supermodel Team
terminate called after throwing an instance of 'std::range_error'
  what():  Node "New3DEngine" does not exist
Aborted (core dumped)
```