### PR TITLE
Implement CRT color emulation

### DIFF
--- a/Config/Supermodel.ini
+++ b/Config/Supermodel.ini
@@ -37,6 +37,11 @@ QuadRendering = false
 WideScreen = false
 Stretch = false
 WideBackground = false
+Supersampling = 1
+; CRT-like color adaption: 0=none, 1=ARI/D93 (recommended for all JP developed games),
+; 2=PVM_20M2U/D93, 3=BT601_525/D93, 4=BT601_525/D65 (recommended for all US developed games)
+; 5=BT601_625/D65 (recommended for all EUR/AUS developed games)
+CRTcolors = 0
 
 ; Refresh rate (milliHertz accuracy). Actual Model 3 refresh rate is 57.524 Hz
 ; but this can cause judder so we use 60 Hz by default.

--- a/Docs/README.txt
+++ b/Docs/README.txt
@@ -1213,6 +1213,25 @@ not.  All options are case sensitive.
 
     ----------------
 
+    Option:         -crtcolors=<mode>
+
+    Description:    Emulates other regional TV standards of the time.
+                    These came with the caveat that displaying video content on
+                    other regions TVs would/should have needed color corrections
+                    (which was usually not done for video games, only broadcasting, etc).
+                    Nowadays the world has settled on the same standards, and we
+                    can transform from the old ones to the (for now) common sRGB.
+
+                    This means one can choose between 6 different mappings now:
+                    0=none (default)
+                    1=ARI/D93 (recommended for all JP developed games, most likely true for all Model 3 games)
+                    2=PVM_20M2U/D93
+                    3=BT601_525/D93
+                    4=BT601_525/D65 (recommended for all US developed games)
+                    5=BT601_625/D65 (recommended for all EUR/AUS developed games)
+
+    ----------------
+
     Option:         -show-fps
 
     Description:    Shows the frame rate in the window title bar.

--- a/Src/Graphics/SuperAA.cpp
+++ b/Src/Graphics/SuperAA.cpp
@@ -1,14 +1,14 @@
 #include "SuperAA.h"
 #include <string>
 
-SuperAA::SuperAA(int aaValue, int CRTcolors) :
+SuperAA::SuperAA(int aaValue, CRTcolor CRTcolors) :
 	m_aa(aaValue),
 	m_crtcolors(CRTcolors),
 	m_vao(0),
 	m_width(0),
 	m_height(0)
 {
-	if ((m_aa > 1) || m_crtcolors) {
+	if ((m_aa > 1) || (m_crtcolors != CRTcolor::None)) {
 
 		static const char* vertexShader = R"glsl(
 
@@ -27,70 +27,17 @@ SuperAA::SuperAA(int aaValue, int CRTcolors) :
 			)glsl";
 
 
-		static const std::string fragmentShaderHeader = R"glsl(
+		static const std::string fragmentShaderVersion = R"glsl(
 			#version 410 core
-
-			// see https://www.retrorgb.com/colour-malarkey.html
-			// and accompanying matrices https://github.com/danmons/colour_matrix_adaptations/tree/main/csv
-			/*1*/const mat3 colARI = mat3(1.3272128334714093, // ARI(D93/9300K) (JP) -> sRGB(D65/6500K) // what can be found in some of the sega or corresponding CRT manuals of the time is a range of ~9700K-10600K, so even cooler than D93
-									-0.3802108879412366,
-									-0.1003607696463202,
-									-0.0241848600268417,
-									0.9544506228550125,
-									0.0807358585208939,
-									-0.0239585810555497,
-									-0.0409736005706461,
-									1.4076563728858242);
-			/*2*/const mat3 colPVM = mat3(0.9241392201737613, // PVM_20M2U(D93/9300K) (JP) -> sRGB(D65/6500K), gamma 2.25
-									-0.0690701363506526,
-									-0.0084279079392561,
-									0.0231962420140721,
-									0.9729221778325590,
-									0.0148832015024337,
-									-0.0054875731998806,
-									0.0098220960740544,
-									1.3383896683854550);
-			/*3*/const mat3 colBT601JP = mat3(0.7822490684754086, // BT601_525_D93 (JP) -> sRGB(D65/6500K), gamma sRGB
-									0.0506168576073398,
-									0.0137752498011040,
-									0.0147968947158740,
-									0.9741745313046067,
-									0.0220301953285839,
-									-0.0013501205469208,
-									-0.0044076726925543,
-									1.3484819844991036);
-			/*4*/const mat3 colBT601US = mat3(0.9395420637732393, // BT601_525 (US) -> sRGB(D65/6500K), gamma sRGB // extremely subtle
-									0.0501813568598678,
-									0.0102765793668928,
-									0.0177722231435608,
-									0.9657928624969044,
-									0.0164349143595347,
-									-0.0016215999431855,
-									-0.0043697496597356,
-									1.0059913496029214);
-			/*5*/const mat3 colBT601EA = mat3(1.0440432087628346, // BT601_625 (EUR,AUS) -> sRGB(D65/6500K), gamma sRGB // barely noticeable at all
-									-0.0440432087628348,
-									0.0000000000000001,
-									0.0000000000000000,
-									1.0000000000000002,
-									0.0000000000000000,
-									0.0000000000000000,
-									0.0117933782840052,
-									0.9882066217159947);
 
 		)glsl";
 
 		std::string aaString = "const int aa = ";
 		aaString += std::to_string(m_aa);
 		aaString += ";\n";
-		std::string ccString = "const int cc = ";
-		ccString += std::to_string(m_crtcolors);
-		ccString += ";\n";
-		std::string cgString = "const float cgamma = ";
-		cgString += (m_crtcolors == 1) ? "2.5" : (m_crtcolors == 2) ? "2.25" : "-1.0"; // what is the 'real' gamma/EOTF of a japanese arcade CRT of that time? 2.4 or 2.5 is what the net so far agrees on
-		cgString += ";\nconst mat3 colmatrix = ";
-		cgString += (m_crtcolors == 1) ? "colARI" : (m_crtcolors == 2) ? "colPVM" : (m_crtcolors == 3) ? "colBT601JP" : (m_crtcolors == 4) ? "colBT601US" : "colBT601EA";
-		cgString += ";\n";
+		std::string ccString = "#define CRTCOLORS ";
+		ccString += std::to_string((int)m_crtcolors);
+		ccString += '\n';
 
 		static const std::string fragmentShader = R"glsl(
 
@@ -99,6 +46,68 @@ SuperAA::SuperAA(int aaValue, int CRTcolors) :
 
 		// outputs
 		out vec4 fragColor;
+
+		#if (CRTCOLORS == 1)
+		const float cgamma = 2.5; // what is the 'real' gamma/EOTF of a japanese arcade CRT of that time? 2.4 or 2.5 is what the net so far agrees on
+		#elif (CRTCOLORS == 2)
+		const float cgamma = 2.25;
+		#elif (CRTCOLORS > 2)
+		const float cgamma = -1.0;
+		#endif
+
+		// see https://www.retrorgb.com/colour-malarkey.html
+		// and accompanying matrices https://github.com/danmons/colour_matrix_adaptations/tree/main/csv
+		#if (CRTCOLORS == 1)
+		const mat3 colmatrix = mat3(1.3272128334714093, // ARI(D93/9300K) (JP) -> sRGB(D65/6500K) // what can be found in some of the sega or corresponding CRT manuals of the time is a range of ~9700K-10600K, so even cooler than D93
+									-0.3802108879412366,
+									-0.1003607696463202,
+									-0.0241848600268417,
+									0.9544506228550125,
+									0.0807358585208939,
+									-0.0239585810555497,
+									-0.0409736005706461,
+									1.4076563728858242);
+		#elif (CRTCOLORS == 2)
+		const mat3 colmatrix = mat3(0.9241392201737613, // PVM_20M2U(D93/9300K) (JP) -> sRGB(D65/6500K), gamma 2.25
+									-0.0690701363506526,
+									-0.0084279079392561,
+									0.0231962420140721,
+									0.9729221778325590,
+									0.0148832015024337,
+									-0.0054875731998806,
+									0.0098220960740544,
+									1.3383896683854550);
+		#elif (CRTCOLORS == 3)
+		const mat3 colmatrix = mat3(0.7822490684754086, // BT601_525_D93 (JP) -> sRGB(D65/6500K), gamma sRGB
+									0.0506168576073398,
+									0.0137752498011040,
+									0.0147968947158740,
+									0.9741745313046067,
+									0.0220301953285839,
+									-0.0013501205469208,
+									-0.0044076726925543,
+									1.3484819844991036);
+		#elif (CRTCOLORS == 4)
+		const mat3 colmatrix = mat3(0.9395420637732393, // BT601_525 (US) -> sRGB(D65/6500K), gamma sRGB // extremely subtle
+									0.0501813568598678,
+									0.0102765793668928,
+									0.0177722231435608,
+									0.9657928624969044,
+									0.0164349143595347,
+									-0.0016215999431855,
+									-0.0043697496597356,
+									1.0059913496029214);
+		#elif (CRTCOLORS == 5)
+		const mat3 colmatrix = mat3(1.0440432087628346, // BT601_625 (EUR,AUS) -> sRGB(D65/6500K), gamma sRGB // barely noticeable at all
+									-0.0440432087628348,
+									0.0000000000000001,
+									0.0000000000000000,
+									1.0000000000000002,
+									0.0000000000000000,
+									0.0000000000000000,
+									0.0117933782840052,
+									0.9882066217159947);
+		#endif
 
 		vec3 GetTextureValue(sampler2D s)
 		{
@@ -118,22 +127,14 @@ SuperAA::SuperAA(int aaValue, int CRTcolors) :
 
 		float sRGB(float color)
 		{
-			//return pow(color, 1.0/2.2);
-
-			//if (!(color > 0.0)) // also covers NaNs
-			//	return 0.0;
-			/*else*/ if (color <= 0.0031308)
+			if (color <= 0.0031308)
 				return 12.92 * color;
-			else //if (color < 1.0)
+			else
 				return 1.055 * pow(color, 1.0/2.4) - 0.055;
-			//else
-			//	return 1.0;
 		}
 
 		float invsRGB(float color)
 		{
-			//return pow(color, 2.2);
-
 			if (color <= 0.04045) // 0.03928 ?
 				return color * (1.0/12.92);
 			else
@@ -144,7 +145,7 @@ SuperAA::SuperAA(int aaValue, int CRTcolors) :
 		{
 			vec3 finalColor = GetTextureValue(tex1);
 
-			if (cc > 0)
+			#if (CRTCOLORS != 0)
 			{
 				// transform input space to linear space
 				if (cgamma != -1.0)
@@ -156,13 +157,14 @@ SuperAA::SuperAA(int aaValue, int CRTcolors) :
 				// transform from linear to sRGB output space
 				finalColor = vec3(sRGB(finalColor.r),sRGB(finalColor.g),sRGB(finalColor.b));
 			}
+			#endif
 
 			fragColor = vec4(finalColor, 1.0);
 		}
 
 		)glsl";
 
-		std::string fragmentShaderString = fragmentShaderHeader + aaString + ccString + cgString + fragmentShader;
+		std::string fragmentShaderString = fragmentShaderVersion + aaString + ccString + fragmentShader;
 
 		// load shaders
 		m_shader.LoadShaders(vertexShader, fragmentShaderString.c_str());
@@ -194,7 +196,7 @@ SuperAA::~SuperAA()
 
 void SuperAA::Init(int width, int height)
 {
-	if ((m_aa > 1) || m_crtcolors) {
+	if ((m_aa > 1) || (m_crtcolors != CRTcolor::None)) {
 		m_fbo.Destroy();
 		m_fbo.Create(width * m_aa, height * m_aa);
 
@@ -205,7 +207,7 @@ void SuperAA::Init(int width, int height)
 
 void SuperAA::Draw()
 {
-	if ((m_aa > 1) || m_crtcolors) {
+	if ((m_aa > 1) || (m_crtcolors != CRTcolor::None)) {
 		glDisable(GL_DEPTH_TEST);
 		glDisable(GL_STENCIL_TEST);
 		glDisable(GL_SCISSOR_TEST);

--- a/Src/Graphics/SuperAA.cpp
+++ b/Src/Graphics/SuperAA.cpp
@@ -1,15 +1,16 @@
 #include "SuperAA.h"
 #include <string>
 
-SuperAA::SuperAA(int aaValue) :
+SuperAA::SuperAA(int aaValue, int CRTcolors) :
 	m_aa(aaValue),
+	m_crtcolors(CRTcolors),
 	m_vao(0),
 	m_width(0),
 	m_height(0)
 {
-	if (aaValue > 1) {
+	if ((m_aa > 1) || m_crtcolors) {
 
-		const char* vertexShader = R"glsl(
+		static const char* vertexShader = R"glsl(
 
 			#version 410 core
 
@@ -26,16 +27,72 @@ SuperAA::SuperAA(int aaValue) :
 			)glsl";
 
 
-		std::string fragmentShaderVersion = R"glsl(
+		static const std::string fragmentShaderHeader = R"glsl(
 			#version 410 core
+
+			// see https://www.retrorgb.com/colour-malarkey.html
+			// and accompanying matrices https://github.com/danmons/colour_matrix_adaptations/tree/main/csv
+			/*1*/const mat3 colARI = mat3(1.3272128334714093, // ARI(D93/9300K) (JP) -> sRGB(D65/6500K) // what can be found in some of the sega or corresponding CRT manuals of the time is a range of ~9700K-10600K, so even cooler than D93
+									-0.3802108879412366,
+									-0.1003607696463202,
+									-0.0241848600268417,
+									0.9544506228550125,
+									0.0807358585208939,
+									-0.0239585810555497,
+									-0.0409736005706461,
+									1.4076563728858242);
+			/*2*/const mat3 colPVM = mat3(0.9241392201737613, // PVM_20M2U(D93/9300K) (JP) -> sRGB(D65/6500K), gamma 2.25
+									-0.0690701363506526,
+									-0.0084279079392561,
+									0.0231962420140721,
+									0.9729221778325590,
+									0.0148832015024337,
+									-0.0054875731998806,
+									0.0098220960740544,
+									1.3383896683854550);
+			/*3*/const mat3 colBT601JP = mat3(0.7822490684754086, // BT601_525_D93 (JP) -> sRGB(D65/6500K), gamma sRGB
+									0.0506168576073398,
+									0.0137752498011040,
+									0.0147968947158740,
+									0.9741745313046067,
+									0.0220301953285839,
+									-0.0013501205469208,
+									-0.0044076726925543,
+									1.3484819844991036);
+			/*4*/const mat3 colBT601US = mat3(0.9395420637732393, // BT601_525 (US) -> sRGB(D65/6500K), gamma sRGB // extremely subtle
+									0.0501813568598678,
+									0.0102765793668928,
+									0.0177722231435608,
+									0.9657928624969044,
+									0.0164349143595347,
+									-0.0016215999431855,
+									-0.0043697496597356,
+									1.0059913496029214);
+			/*5*/const mat3 colBT601EA = mat3(1.0440432087628346, // BT601_625 (EUR,AUS) -> sRGB(D65/6500K), gamma sRGB // barely noticeable at all
+									-0.0440432087628348,
+									0.0000000000000001,
+									0.0000000000000000,
+									1.0000000000000002,
+									0.0000000000000000,
+									0.0000000000000000,
+									0.0117933782840052,
+									0.9882066217159947);
 
 		)glsl";
 
 		std::string aaString = "const int aa = ";
-		aaString += std::to_string(aaValue);
+		aaString += std::to_string(m_aa);
 		aaString += ";\n";
+		std::string ccString = "const int cc = ";
+		ccString += std::to_string(m_crtcolors);
+		ccString += ";\n";
+		std::string cgString = "const float cgamma = ";
+		cgString += (m_crtcolors == 1) ? "2.5" : (m_crtcolors == 2) ? "2.25" : "-1.0"; // what is the 'real' gamma/EOTF of a japanese arcade CRT of that time? 2.4 or 2.5 is what the net so far agrees on
+		cgString += ";\nconst mat3 colmatrix = ";
+		cgString += (m_crtcolors == 1) ? "colARI" : (m_crtcolors == 2) ? "colPVM" : (m_crtcolors == 3) ? "colBT601JP" : (m_crtcolors == 4) ? "colBT601US" : "colBT601EA";
+		cgString += ";\n";
 
-		std::string fragmentShader = R"glsl(
+		static const std::string fragmentShader = R"glsl(
 
 		// inputs
 		uniform sampler2D tex1;			// base tex
@@ -59,14 +116,53 @@ SuperAA::SuperAA(int aaValue) :
 			return texColour;
 		}
 
+		float sRGB(float color)
+		{
+			//return pow(color, 1.0/2.2);
+
+			//if (!(color > 0.0)) // also covers NaNs
+			//	return 0.0;
+			/*else*/ if (color <= 0.0031308)
+				return 12.92 * color;
+			else //if (color < 1.0)
+				return 1.055 * pow(color, 1.0/2.4) - 0.055;
+			//else
+			//	return 1.0;
+		}
+
+		float invsRGB(float color)
+		{
+			//return pow(color, 2.2);
+
+			if (color <= 0.04045) // 0.03928 ?
+				return color * (1.0/12.92);
+			else
+				return pow(color * (1.0/1.055) + (0.055/1.055), 2.4);
+		}
+
 		void main()
 		{
-			fragColor = vec4(GetTextureValue(tex1), 1.0);
+			vec3 finalColor = GetTextureValue(tex1);
+
+			if (cc > 0)
+			{
+				// transform input space to linear space
+				if (cgamma != -1.0)
+					finalColor = pow(finalColor, vec3(cgamma));
+				else
+					finalColor = vec3(invsRGB(finalColor.r),invsRGB(finalColor.g),invsRGB(finalColor.b));
+				// do color transformation
+				finalColor *= colmatrix;
+				// transform from linear to sRGB output space
+				finalColor = vec3(sRGB(finalColor.r),sRGB(finalColor.g),sRGB(finalColor.b));
+			}
+
+			fragColor = vec4(finalColor, 1.0);
 		}
 
 		)glsl";
 
-		std::string fragmentShaderString = fragmentShaderVersion + aaString + fragmentShader;
+		std::string fragmentShaderString = fragmentShaderHeader + aaString + ccString + cgString + fragmentShader;
 
 		// load shaders
 		m_shader.LoadShaders(vertexShader, fragmentShaderString.c_str());
@@ -98,7 +194,7 @@ SuperAA::~SuperAA()
 
 void SuperAA::Init(int width, int height)
 {
-	if (m_aa > 1) {
+	if ((m_aa > 1) || m_crtcolors) {
 		m_fbo.Destroy();
 		m_fbo.Create(width * m_aa, height * m_aa);
 
@@ -109,7 +205,7 @@ void SuperAA::Init(int width, int height)
 
 void SuperAA::Draw()
 {
-	if (m_aa > 1) {
+	if ((m_aa > 1) || m_crtcolors) {
 		glDisable(GL_DEPTH_TEST);
 		glDisable(GL_STENCIL_TEST);
 		glDisable(GL_SCISSOR_TEST);

--- a/Src/Graphics/SuperAA.h
+++ b/Src/Graphics/SuperAA.h
@@ -12,11 +12,11 @@
 class SuperAA
 {
 public:
-	SuperAA(int aaValue);		
+	SuperAA(int aaValue, int CRTcolors);
 	~SuperAA();
 
 	void Init(int width, int height);		// width & height are real window dimensions
-	void Draw();							// this is a no-op if AA is 1, since we'll be drawing straight on the back buffer anyway
+	void Draw();							// this is a no-op if AA is 1 and CRTcolors 0, since we'll be drawing straight on the back buffer anyway
 
 	GLuint GetTargetID();
 
@@ -24,8 +24,8 @@ private:
 	FBO m_fbo;
 	GLSLShader m_shader;
 	const int m_aa;
+	const int m_crtcolors;
 	GLuint m_vao;
 	int m_width;
 	int m_height;
 };
-

--- a/Src/Graphics/SuperAA.h
+++ b/Src/Graphics/SuperAA.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Supermodel.h"
 #include "FBO.h"
 #include "New3D/GLSLShader.h"
 
@@ -12,7 +13,7 @@
 class SuperAA
 {
 public:
-	SuperAA(int aaValue, int CRTcolors);
+	SuperAA(int aaValue, CRTcolor CRTcolors);
 	~SuperAA();
 
 	void Init(int width, int height);		// width & height are real window dimensions
@@ -24,7 +25,7 @@ private:
 	FBO m_fbo;
 	GLSLShader m_shader;
 	const int m_aa;
-	const int m_crtcolors;
+	const CRTcolor m_crtcolors;
 	GLuint m_vao;
 	int m_width;
 	int m_height;

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -131,7 +131,7 @@ static unsigned  xOffset, yOffset;      // offset of renderer output within Open
 static unsigned  xRes, yRes;            // renderer output resolution (can be smaller than GL viewport)
 static unsigned  totalXRes, totalYRes;  // total resolution (the whole GL viewport)
 static int aaValue = 1;                 // default is 1 which is no aa
-static int CRTcolors = 0;               // default is 0 which is no gamma/color adaption being done
+static CRTcolor CRTcolors = CRTcolor::None; // default to no gamma/color adaption being done
 
 /*
  * Crosshair stuff
@@ -2040,7 +2040,7 @@ int main(int argc, char **argv)
   std::string selectedInputSystem = s_runtime_config["InputSystem"].ValueAs<std::string>();
 
   aaValue = s_runtime_config["Supersampling"].ValueAs<int>();
-  CRTcolors = s_runtime_config["CRTcolors"].ValueAs<int>();
+  CRTcolors = (CRTcolor)s_runtime_config["CRTcolors"].ValueAs<int>();
 
   // Create a window
   xRes = 496;

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -131,6 +131,7 @@ static unsigned  xOffset, yOffset;      // offset of renderer output within Open
 static unsigned  xRes, yRes;            // renderer output resolution (can be smaller than GL viewport)
 static unsigned  totalXRes, totalYRes;  // total resolution (the whole GL viewport)
 static int aaValue = 1;                 // default is 1 which is no aa
+static int CRTcolors = 0;               // default is 0 which is no gamma/color adaption being done
 
 /*
  * Crosshair stuff
@@ -991,7 +992,7 @@ int Supermodel(const Game &game, ROMSet *rom_set, IEmulator *Model3, CInputs *In
   uint64_t nextTime = 0;
 
   // Initialize the renderers
-  SuperAA* superAA = new SuperAA(aaValue);
+  SuperAA* superAA = new SuperAA(aaValue, CRTcolors);
   superAA->Init(totalXRes, totalYRes);  // pass actual frame sizes here
   CRender2D *Render2D = new CRender2D(s_runtime_config);
   IRender3D *Render3D = s_runtime_config["New3DEngine"].ValueAs<bool>() ? ((IRender3D *) new New3D::CNew3D(s_runtime_config, Model3->GetGame().name)) : ((IRender3D *) new Legacy3D::CLegacy3D(s_runtime_config));
@@ -1501,6 +1502,7 @@ static Util::Config::Node DefaultConfig()
   config.Set("FullScreen", false);
   config.Set("BorderlessWindow", false);
   config.Set("Supersampling", 1);
+  config.Set("CRTcolors", int(0));
   config.Set("WideScreen", false);
   config.Set("Stretch", false);
   config.Set("WideBackground", false);
@@ -1589,6 +1591,7 @@ static void Help(void)
   puts("  -wide-bg                When wide-screen mode is enabled, also expand the 2D");
   puts("                          background layer to screen width");
   puts("  -stretch                Fit viewport to resolution, ignoring aspect ratio");
+  puts("  -crtcolors=<n>          CRT color emulation (range 0-5)");
   puts("  -no-throttle            Disable frame rate lock");
   puts("  -vsync                  Lock to vertical refresh rate [Default]");
   puts("  -no-vsync               Do not lock to vertical refresh rate");
@@ -1865,6 +1868,29 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
               }
           }
       }
+      else if (arg == "-crtcolors" || arg.find("-crtcolors=") == 0) {
+
+          std::vector<std::string> parts = Util::Format(arg).Split('=');
+
+          if (parts.size() != 2)
+          {
+              ErrorLog("'-crtcolors' requires an integer argument (e.g., '-crtcolors=1').");
+              cmd_line.error = true;
+          }
+          else {
+
+              try {
+                  int val = std::stoi(parts[1]);
+                  val = std::clamp(val, 0, 5);
+
+                  cmd_line.config.Set("CRTcolors", val);
+              }
+              catch (...) {
+                  ErrorLog("'-crtcolors' requires an integer argument (e.g., '-crtcolors=1').");
+                  cmd_line.error = true;
+              }
+          }
+      }
       else if (arg == "-true-hz")
         cmd_line.config.Set("RefreshRate", 57.524f);
       else if (arg == "-print-gl-info")
@@ -2014,6 +2040,7 @@ int main(int argc, char **argv)
   std::string selectedInputSystem = s_runtime_config["InputSystem"].ValueAs<std::string>();
 
   aaValue = s_runtime_config["Supersampling"].ValueAs<int>();
+  CRTcolors = s_runtime_config["CRTcolors"].ValueAs<int>();
 
   // Create a window
   xRes = 496;

--- a/Src/Supermodel.h
+++ b/Src/Supermodel.h
@@ -94,6 +94,21 @@
 // Error logging interface
 #include "OSD/Logger.h"
 
+// CRT/TV color transformations
+#ifdef __cplusplus
+enum class CRTcolor
+#else
+enum CRTcolor
+#endif
+{
+	None = 0,
+	ARI = 1,
+	PVM = 2,
+	BT601JP = 3,
+	BT601US = 4,
+	BT601EA = 5
+};
+
 
 /******************************************************************************
  Helpful Macros and Inlines


### PR DESCRIPTION
so not scanlines or other CRT aspects, just the differences in the region-specific TV color standards of the time. These came with the caveat that displaying video content on other regions TVs would/should have needed color corrections (which was usually not done for video games, only broadcasting, etc). Nowadays the world has settled on the same standards and we can transform from the old ones to the (for now) common sRGB.

This means one can choose between 6 different mappings now:
0=none (as before/default)
1=ARI/D93 (recommended for all JP developed games)
2=PVM_20M2U/D93
3=BT601_525/D93
4=BT601_525/D65 (recommended for all US developed games)
5=BT601_625/D65 (recommended for all EUR/AUS developed games)

wired into the supersampling summation pass, as this is the final output pass

addresses #189 