### PR TITLE
improve SuperSleepUntil implementation

### DIFF
--- a/Src/Network/SimNetBoard.cpp
+++ b/Src/Network/SimNetBoard.cpp
@@ -20,10 +20,10 @@
  ** with Supermodel.  If not, see <http://www.gnu.org/licenses/>.
  **/
 
-#include <chrono>
 #include <thread>
 #include "Supermodel.h"
 #include "SimNetBoard.h"
+#include <OSD/Thread.h>
 
  // these make 16-bit read/writes much neater
 #define RAM16 *(uint16_t*)&RAM
@@ -527,8 +527,6 @@ void CSimNetBoard::GetGame(const Game& gameInfo)
 
 void CSimNetBoard::ConnectProc(void)
 {
-	using namespace std::chrono_literals;
-
 	if (m_connected)
 		return;
 
@@ -546,7 +544,7 @@ void CSimNetBoard::ConnectProc(void)
 	{
 		if (m_quit)
 			return;
-		std::this_thread::sleep_for(1ms);
+		CThread::Sleep(1);
 	}
 
 	printf("Successfully connected.\n");

--- a/Src/Network/TCPReceive.cpp
+++ b/Src/Network/TCPReceive.cpp
@@ -22,9 +22,7 @@
 
 #include "TCPReceive.h"
 #include "OSD/Logger.h"
-#include <chrono>
-
-using namespace std::chrono_literals;
+#include "OSD/Thread.h"
 
 #if defined(_DEBUG)
 #include <stdio.h>
@@ -98,9 +96,7 @@ std::vector<char>& TCPReceive::Receive()
 	}
 
 	int size = 0;
-	int result = 0;
-
-	result = SDLNet_TCP_Recv(m_receiveSocket, &size, sizeof(int));
+	int result = SDLNet_TCP_Recv(m_receiveSocket, &size, sizeof(int));
 	DPRINTF("Received %i bytes\n", result);
 	if (result <= 0) {
 		SDLNet_TCP_Close(m_receiveSocket);
@@ -130,7 +126,7 @@ void TCPReceive::ListenFunc()
 {
 	while (m_running) {
 
-		std::this_thread::sleep_for(16ms);
+		CThread::Sleep(16);
 		if (m_receiveSocket) continue;
 
 		auto socket = SDLNet_TCP_Accept(m_listenSocket);

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -898,7 +898,9 @@ static void SuperSleepUntil(const uint64_t target)
     // according to all available processor documentation for x86 and arm,
     // spinning should pause the processor for a short while for better
     // power efficiency and (surprisingly) overall faster system performance
+    #ifdef SDL_CPUPauseInstruction
     SDL_CPUPauseInstruction();
+    #endif
     remain = target - SDL_GetPerformanceCounter();
   } while (remain > 0);
 }

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -102,10 +102,6 @@
 
 #include "Crosshair.h"
 
-#if (defined(_M_X64) || defined(__x86_64__))
-#include <emmintrin.h>
-#endif
-
 /******************************************************************************
  Global Run-time Config
 ******************************************************************************/
@@ -902,13 +898,7 @@ static void SuperSleepUntil(const uint64_t target)
     // according to all available processor documentation for x86 and arm,
     // spinning should pause the processor for a short while for better
     // power efficiency and (surprisingly) overall faster system performance
-#ifdef _WIN32
-    YieldProcessor();
-#elif (defined(_M_X64) || defined(__x86_64__))
-    _mm_pause();
-#elif (defined(_M_ARM64) || defined(__aarch64__))
-    __asm__ __volatile__("isb\n"); // as researched by Rust devs
-#endif
+    SDL_CPUPauseInstruction();
     remain = target - SDL_GetPerformanceCounter();
   } while (remain > 0);
 }

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -102,6 +102,10 @@
 
 #include "Crosshair.h"
 
+#if (defined(_M_X64) || defined(__x86_64__))
+#include <emmintrin.h>
+#endif
+
 /******************************************************************************
  Global Run-time Config
 ******************************************************************************/
@@ -873,33 +877,40 @@ static uint64_t GetDesiredRefreshRateMilliHz()
   return refreshRateMilliHz;
 }
 
-static void SuperSleepUntil(uint64_t target)
+static void SuperSleepUntil(const uint64_t target)
 {
   uint64_t time = SDL_GetPerformanceCounter();
 
   // If we're ahead of the target, we're done
-  if (time > target)
+  if (time >= target)
   {
     return;
   }
 
-  // Compute the whole number of millis to sleep. Because OS sleep is not accurate,
-  // we actually sleep for one less and will spin-wait for the final millisecond.
-  int32_t numWholeMillisToSleep = int32_t((target - time) * 1000 / s_perfCounterFrequency);
-  numWholeMillisToSleep -= 1;
-  if (numWholeMillisToSleep > 0)
+  // Because OS sleep is not accurate,
+  // we actually sleep until a maximum of 2 milliseconds are left.
+  while (int64_t(target - time) * 1000 > 2 * int64_t(s_perfCounterFrequency))
   {
-    SDL_Delay(numWholeMillisToSleep);
+    SDL_Delay(1);
+    time = SDL_GetPerformanceCounter();
   }
 
   // Spin until requested time
-  volatile uint64_t now;
-  int32_t remain;
+  int64_t remain;
   do
   {
-    now = SDL_GetPerformanceCounter();
-    remain = int32_t((target - now));
-  } while (remain>0);
+    // according to all available processor documentation for x86 and arm,
+    // spinning should pause the processor for a short while for better
+    // power efficiency and (surprisingly) overall faster system performance
+#ifdef _WIN32
+    YieldProcessor();
+#elif (defined(_M_X64) || defined(__x86_64__))
+    _mm_pause();
+#elif (defined(_M_ARM64) || defined(__aarch64__))
+    __asm__ __volatile__("isb\n"); // as researched by Rust devs
+#endif
+    remain = target - SDL_GetPerformanceCounter();
+  } while (remain > 0);
 }
 
 
@@ -977,7 +988,7 @@ int Supermodel(const Game &game, ROMSet *rom_set, IEmulator *Model3, CInputs *In
   if (gameHasLightguns)
     videoInputs = Inputs;
   else
-    videoInputs = NULL;
+    videoInputs = nullptr;
 
   // Attach the inputs to the emulator
   Model3->AttachInputs(Inputs);


### PR DESCRIPTION
1) as found in lots of experiments done for the VPX and PinMAME projects, Sleep() on windows can oversleep for over 1ms, especially when doing Sleep(>1)
2) thus loop Sleep(1) and end if its less than 2ms
3) in the spin to wait for the rest of the time, insert yield(=_mm_pause) or the determined by the Rust devs arm64 equivalent

This actually gets rid of micro-stutter on my AMD based minipc e.g. in Daytona2 (see #178)

Then also use same Sleep() implementation in the network code (to avoid potential sideeffects between the 2 implementations)