### PR TITLE
DPI awareness

### DIFF
--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -2058,6 +2058,9 @@ int main(int argc, char **argv)
     return 1;
   }
 
+  // Flag as DPI-aware, otherwise the window content might be scaled by some graphics drivers
+  SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "system");
+
   // Begin initializing various subsystems...
   int exitCode = 0;
   IEmulator *Model3 = nullptr;


### PR DESCRIPTION
Flag SDL window as DPI-aware, otherwise the window content might be scaled by some windows graphics drivers

addresses #206