### PR TITLE
Properly enable fesetround/fegetround usage

### DIFF
--- a/Src/CPU/PowerPC/ppc_ops.c
+++ b/Src/CPU/PowerPC/ppc_ops.c
@@ -2171,14 +2171,14 @@ static void ppc_fctiwx(UINT32 op)
 
 	if(r > (INT64)((INT32)0x7FFFFFFF))
 	{
-		FPR(t).id = 0x7FFFFFFF;
+		FPR(t).id = (INT64)((INT32)0x7FFFFFFF);
 		// FPSCR[FR] = 0
 		// FPSCR[FI] = 1
 		// FPSCR[XX] = 1
 	}
 	else if(r < (INT64)((INT32)0x80000000))
 	{
-		FPR(t).id = 0x80000000;
+		FPR(t).id = (INT64)((INT32)0x80000000);
 		// FPSCR[FR] = 1
 		// FPSCR[FI] = 1
 		// FPSCR[XX] = 1
@@ -2210,9 +2210,9 @@ static void ppc_fctiwzx(UINT32 op)
 	SET_VXSNAN_1(FPR(b));
 	r = (INT64)trunc(FPR(b).fd);
 
-	if(r > (INT64)((INT32)0x7fffffff))
+	if(r > (INT64)((INT32)0x7FFFFFFF))
 	{
-		FPR(t).id = 0x7fffffff;
+		FPR(t).id = (INT64)((INT32)0x7FFFFFFF);
 		// FPSCR[FR] = 0
 		// FPSCR[FI] = 1
 		// FPSCR[XX] = 1
@@ -2220,7 +2220,7 @@ static void ppc_fctiwzx(UINT32 op)
 	}
 	else if(r < (INT64)((INT32)0x80000000))
 	{
-		FPR(t).id = 0x80000000;
+		FPR(t).id = (INT64)((INT32)0x80000000);
 		// FPSCR[FR] = 1
 		// FPSCR[FI] = 1
 		// FPSCR[XX] = 1

--- a/Src/CPU/PowerPC/ppc_ops.c
+++ b/Src/CPU/PowerPC/ppc_ops.c
@@ -1571,6 +1571,10 @@ inline INT64 round_toward_negative_infinity(FPR f)
 }
 */
 
+// the following operations/functions CAN BREAK if fast math compiler options (i.e. finite math only) are enabled.
+// std::isnan is definetly ignored by GCC/clang then, and there are even fancier compiler heuristics that
+// can detect the bit fiddling ops to detect infinity, nan and denorms and then even may ignore these!
+// (the latter currently (2024) the case in non-production/experimental clang builds)
 inline bool is_nan_double(FPR x)
 {
 	return std::isnan(x.fd);
@@ -2748,7 +2752,7 @@ static void ppc_fselx(UINT32 op)
 
 	CHECK_FPU_AVAILABLE();
 
-	FPR(t).fd = (FPR(a).fd >= 0.0) ? FPR(c).fd : FPR(b).fd;
+	FPR(t).fd = (is_nan_double(FPR(a)) || FPR(a).fd < 0.0) ? FPR(b).fd : FPR(c).fd; // do not just sign check, as -0.0 also counts as +0.0
 
 	if( RCBIT ) {
 		SET_CR1();

--- a/Src/CPU/PowerPC/ppc_ops.c
+++ b/Src/CPU/PowerPC/ppc_ops.c
@@ -1539,8 +1539,7 @@ static void ppc_invalid(UINT32 op)
   Floating point operations.
 */
 
-/*************************OLD
-
+/* UNUSED
 inline INT64 round_to_nearest(FPR f)
 {
 	//return (INT64)(f.fd + 0.5);
@@ -1572,50 +1571,43 @@ inline INT64 round_toward_negative_infinity(FPR f)
 }
 */
 
-
-// New below, based on changes in MAME
-inline int is_nan_double(FPR x)
+inline bool is_nan_double(FPR x)
 {
-	return( ((x.id & DOUBLE_EXP) == DOUBLE_EXP) &&
-			((x.id & DOUBLE_FRAC) != DOUBLE_ZERO) );
+	return std::isnan(x.fd);
 }
 
-inline int is_qnan_double(FPR x)
+inline bool is_qnan_double(FPR x)
 {
-	return( ((x.id & DOUBLE_EXP) == DOUBLE_EXP) &&
-			((x.id & 0x0007fffffffffffULL) == 0x000000000000000ULL) &&
-			((x.id & 0x000800000000000ULL) == 0x000800000000000ULL) );
+	UINT64 expfrac = (x.id & (DOUBLE_EXP | DOUBLE_FRAC));
+	return (expfrac >= (DOUBLE_EXP | 0x0008000000000000ULL));
 }
 
-inline int is_snan_double(FPR x)
+inline bool is_snan_double(FPR x)
 {
-	return( ((x.id & DOUBLE_EXP) == DOUBLE_EXP) &&
-			((x.id & DOUBLE_FRAC) != DOUBLE_ZERO) &&
-			((x.id & (0x0008000000000000ULL)) == DOUBLE_ZERO) );
+	UINT64 expfrac = (x.id & (DOUBLE_EXP | DOUBLE_FRAC));
+	return ((expfrac > DOUBLE_EXP) && (expfrac < (DOUBLE_EXP | 0x0008000000000000ULL)));
 }
 
-inline int is_infinity_double(FPR x)
+inline bool is_infinity_double(FPR x)
 {
-	return( ((x.id & DOUBLE_EXP) == DOUBLE_EXP) &&
-			((x.id & DOUBLE_FRAC) == DOUBLE_ZERO) );
+	return ((x.id & (DOUBLE_EXP | DOUBLE_FRAC)) == DOUBLE_EXP);
 }
 
-inline int is_normalized_double(FPR x)
+inline bool is_normalized_double(FPR x)
 {
-	UINT64 exp = (x.id & DOUBLE_EXP) >> 52;
-
-	return (exp >= 1) && (exp <= 2046);
+	UINT64 exp = (x.id & DOUBLE_EXP);
+	return ((exp > 0) && (exp <= (2046ull << 52)));
 }
 
-inline int is_denormalized_double(FPR x)
+inline bool is_denormalized_double(FPR x)
 {
-	return( ((x.id & DOUBLE_EXP) == 0) &&
-			((x.id & DOUBLE_FRAC) != DOUBLE_ZERO) );
+	UINT64 expfrac = (x.id & (DOUBLE_EXP | DOUBLE_FRAC));
+	return ((expfrac > 0) && (expfrac <= DOUBLE_FRAC));
 }
 
-inline int sign_double(FPR x)
+inline bool sign_double(FPR x)
 {
-	return ((x.id & DOUBLE_SIGN) != 0);
+	return (x.id >> 63);
 }
 
 // in theory the following 3 functions require compiler options to work correctly


### PR DESCRIPTION
..according to the C++ spec

unfortunately, e.g. MSVC ignores this pragma, so use what MSDN suggests in that case (GCC and clang may still require -frounding-math for compilation of at least this file)

in addition, do not set fesetround mode once, but just each time before each math op that requires it otherwise other Supermodel code may use the wrong rounding modes (as it relies by default on it being FE_TONEAREST) note that changing the rounding mode is extremely rare, so this will not affect Supermodels performance by much

and fix additional minor issue in ppc_fctiwx

this fixes #203, maybe other emulation+math precision issues, too