### PR TITLE
Hooking up MIDI output from soundboard

### DIFF
--- a/Config/Games.xml
+++ b/Config/Games.xml
@@ -1217,7 +1217,7 @@
     <!-- Correct dump of Magical Truck Adventure, redumped September 2022. -->
     <identity>
       <title>Magical Truck Adventure</title>
-      <version>Japan</version>
+      <version>Export</version>
       <manufacturer>Sega</manufacturer>
       <year>1998</year>
     </identity>
@@ -1288,7 +1288,7 @@
     -->
     <identity>
       <title>Magical Truck Adventure</title>
-      <version>Japan</version>
+      <version>Export</version>
       <manufacturer>Sega</manufacturer>
       <year>1998</year>
     </identity>

--- a/Config/Games.xml
+++ b/Config/Games.xml
@@ -1233,8 +1233,8 @@
     </hardware>
     <roms>
       <patches>
-	    <!-- Enable Region change (remove the patch to return to Japan region) -->
-        <patch region="crom" bits="32" offset="0x14B25C" value="0x38600001" />
+        <!-- Force region to Japan -->
+        <!--<patch region="crom" bits="32" offset="0x001794" value="0x38000000" />-->
       </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-21434.20" crc32="0x18F8626A" />
@@ -1306,8 +1306,8 @@
       <patches>
 	    <!-- Fixing bad ROM dump which causes attract mode to stop rendering -->
         <patch region="crom" bits="32" offset="0x091A34" value="0x917F0068" />
-        <!-- Enable Region change (remove the patch to return to Japan region) -->
-        <patch region="crom" bits="32" offset="0x14B25C" value="0x38600001" />
+        <!-- Force region to Japan -->
+        <!--<patch region="crom" bits="32" offset="0x001794" value="0x38000000" />-->
       </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-21434.20" crc32="0xE028D7CA" />

--- a/Src/Model3/SoundBoard.cpp
+++ b/Src/Model3/SoundBoard.cpp
@@ -330,11 +330,28 @@ int SCSP68KRunCallback(int numCycles)
  Sound Board Interface
 ******************************************************************************/
 
+UINT8 CSoundBoard::ReadMIDIPort(void)
+{
+	UINT8 result = SCSP_MidiOutR();
+	return result;
+}
+
 void CSoundBoard::WriteMIDIPort(UINT8 data)
 {
 	SCSP_MidiIn(data);
 	if (NULL != DSB)	// DSB receives all commands as well
 		DSB->SendCommand(data);
+}
+
+UINT8 CSoundBoard::CheckMIDIStatus(void)
+{
+	UINT8 status = 0x80;
+	if (SCSP_MidiInFill() < 256)	// MIDI input buffer not full
+		status |= 1;
+	if (SCSP_MidiOutFill() > 0)		// MIDI output buffer not empty
+		status |= 2;
+
+	return status;
 }
 
 #ifdef SUPERMODEL_LOG_AUDIO

--- a/Src/Model3/SoundBoard.h
+++ b/Src/Model3/SoundBoard.h
@@ -75,6 +75,16 @@ public:
 	void Write32(UINT32 addr, UINT32 data);
 
 	/*
+	 * ReadMIDIPort(void):
+	 *
+	 * Reads from the sound board MIDI port.
+	 * 
+	 * Returns:
+	 *		Data read from MIDI port.
+	 */
+	UINT8 ReadMIDIPort(void);
+
+	/*
 	 * WriteMIDIPort(data):
 	 *
 	 * Writes to the sound board MIDI port.
@@ -83,6 +93,16 @@ public:
 	 *		data	Byte to write to MIDI port.
 	 */
 	void WriteMIDIPort(UINT8 data);
+
+	/*
+	 * CheckMIDIStatus(void):
+	 * 
+	 * Checks status of MIDI input/output buffers.
+	 * 
+	 * Returns:
+	 *		Status of MIDI input/output buffers.
+	 */
+	UINT8 CheckMIDIStatus(void);
 
 	/*
 	 * SaveState(SaveState):

--- a/Src/Sound/SCSP.cpp
+++ b/Src/Sound/SCSP.cpp
@@ -1757,8 +1757,8 @@ void SCSP_MidiOutW(BYTE val)
 
 	//printf("68K: MIDI out\n");
 	//DebugLog("Midi Out Buffer push %02X",val);
-	MidiStack[MidiOutW++]=val;
-	MidiOutW&=31;
+	MidiOutStack[MidiOutW++]=val;
+	MidiOutW &= 3;
 	++MidiOutFill;
 
 	if (s_multiThreaded)
@@ -1779,9 +1779,9 @@ unsigned char SCSP_MidiOutR()
 	if (s_multiThreaded)
 		MIDILock->Lock();
 
-	val=MidiStack[MidiOutR++];
+	val=MidiOutStack[MidiOutR++];
 	//DebugLog("Midi Out Buffer pop %02X",val);
-	MidiOutR&=31;
+	MidiOutR&=3;
 	--MidiOutFill;
 
 	if (s_multiThreaded)


### PR DESCRIPTION
Used by Magical Truck Adventure to check region code; ROM in Games.xml is Export version, not Japan.

The patch to enable region change is no longer required and has been removed. A new patch to set the region to Japan has been added but commented out to disable it by default.

I don't really like how I have hardcoded the MIDI FIFO sizes in CheckMIDIStatus(); I think adding functions to SCSP.cpp such as SCSP_MidiInFull() and SCSP_MidiOutEmpty() would be a cleaner way to do it. Thoughts?