### PR TITLE
Implement "Block Culling" modeword bit of Mercury ASIC

### DIFF
--- a/Src/Graphics/IRender3D.h
+++ b/Src/Graphics/IRender3D.h
@@ -20,6 +20,7 @@ public:
   virtual void SetStepping(int stepping) = 0;
   virtual Result Init(unsigned xOffset, unsigned yOffset, unsigned xRes, unsigned yRes, unsigned totalXRes, unsigned totalYRes, unsigned aaTarget) = 0;
   virtual void SetSunClamp(bool enable) = 0;
+  virtual void SetBlockCulling(bool enable) = 0;
   virtual float GetLosValue(int layer) = 0;
 
   virtual ~IRender3D()

--- a/Src/Graphics/Legacy3D/Legacy3D.cpp
+++ b/Src/Graphics/Legacy3D/Legacy3D.cpp
@@ -967,6 +967,19 @@ void CLegacy3D::RenderFrame(void)
   if (m_aaTarget) {
       glBindFramebuffer(GL_FRAMEBUFFER, m_aaTarget);			// if we have an AA target draw to it instead of the default back buffer
   }
+
+  if (blockCulling && !m_config["NoWhiteFlash"].ValueAs<bool>())    // block culling disables 3D rendering
+  {
+      // clear screen to white
+      glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+      glClear(GL_COLOR_BUFFER_BIT);
+
+      if (m_aaTarget) {
+          glBindFramebuffer(GL_FRAMEBUFFER, 0);
+      }
+
+      return;
+  }
   
   // Z buffering (Z buffer is cleared by display list viewport nodes)
   glDepthFunc(GL_LESS);
@@ -1312,6 +1325,7 @@ void CLegacy3D::SetSunClamp(bool enable)
 
 void CLegacy3D::SetBlockCulling(bool enable)
 {
+    blockCulling = enable;
 }
 
 float CLegacy3D::GetLosValue(int layer)

--- a/Src/Graphics/Legacy3D/Legacy3D.cpp
+++ b/Src/Graphics/Legacy3D/Legacy3D.cpp
@@ -1310,6 +1310,10 @@ void CLegacy3D::SetSunClamp(bool enable)
 {
 }
 
+void CLegacy3D::SetBlockCulling(bool enable)
+{
+}
+
 float CLegacy3D::GetLosValue(int layer)
 {
 	return 0.0f;

--- a/Src/Graphics/Legacy3D/Legacy3D.h
+++ b/Src/Graphics/Legacy3D/Legacy3D.h
@@ -341,6 +341,16 @@ public:
 	void SetSunClamp(bool enable);
 
 	/*
+	* SetBlockCulling(bool enable);
+	* 
+	* When enabled, clears screen to white and disables 3D rendering
+	* 
+	* Parameters:
+	*		enable	Set block culling
+	*/
+	void SetBlockCulling(bool enable);
+
+	/*
 	* GetLosValue(int layer);
 	*
 	* Gets the line of sight value for the priority layer

--- a/Src/Graphics/Legacy3D/Legacy3D.h
+++ b/Src/Graphics/Legacy3D/Legacy3D.h
@@ -530,6 +530,9 @@ private:
  	 * before being uploaded. Dimensions are 512x512.
  	 */
 	GLfloat	*textureBuffer;	// RGBA8 format
+
+	// JTAG configuration settings
+	bool blockCulling;
 };
 
 } // Legacy3D

--- a/Src/Graphics/New3D/New3D.cpp
+++ b/Src/Graphics/New3D/New3D.cpp
@@ -53,6 +53,7 @@ CNew3D::CNew3D(const Util::Config::Node &config, const std::string& gameName) :
 	}
 
 	m_wideScreen = config["WideScreen"].ValueAs<bool>();
+	m_noWhiteFlash = config["NoWhiteFlash"].ValueAs<bool>();
 
 	m_r3dShader.LoadShader();
 	glUseProgram(0);
@@ -408,6 +409,23 @@ void CNew3D::RenderFrame(void)
 	m_nodes.clear();				// memory will grow during the object life time, that's fine, no need to shrink to fit
 	m_modelMat.Release();			// would hope we wouldn't need this but no harm in checking
 	m_nodeAttribs.Reset();
+
+	if (m_blockCulling && !m_noWhiteFlash)		// block culling disables 3D rendering
+	{
+		if (m_aaTarget) {
+			glBindFramebuffer(GL_FRAMEBUFFER, m_aaTarget);		// if we have an AA target draw to it instead of the default back buffer
+		}
+
+		// clear screen to white
+		glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+		glClear(GL_COLOR_BUFFER_BIT);
+
+		if (m_aaTarget) {
+			glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		}
+
+		return;
+	}
 
 	RenderViewport(0x800000);						// build model structure
 	
@@ -1626,6 +1644,11 @@ void CNew3D::TranslateTexture(unsigned& x, unsigned& y, int width, int height, i
 void CNew3D::SetSunClamp(bool enable)
 {
 	m_sunClamp = enable;
+}
+
+void CNew3D::SetBlockCulling(bool enable)
+{
+	m_blockCulling = enable;
 }
 
 float CNew3D::GetLosValue(int layer)

--- a/Src/Graphics/New3D/New3D.h
+++ b/Src/Graphics/New3D/New3D.h
@@ -155,6 +155,16 @@ public:
 	void SetSunClamp(bool enable);
 
 	/*
+	* SetBlockCulling(bool enable);
+	*
+	* When enabled, clears screen to white and disables 3D rendering
+	*
+	* Parameters:
+	*		enable	Set block culling
+	*/
+	void SetBlockCulling(bool enable);
+
+	/*
 	* GetLosValue(int layer);
 	*
 	* Gets the line of sight value for the priority layer
@@ -228,6 +238,8 @@ private:
 
 	// GPU configuration
 	bool m_sunClamp;
+	bool m_blockCulling;
+	bool m_noWhiteFlash;
 
 	// Stepping
 	int		m_step;

--- a/Src/Model3/Real3D.cpp
+++ b/Src/Model3/Real3D.cpp
@@ -729,6 +729,9 @@ void CReal3D::WriteJTAGModeword(CASIC::Name device, uint32_t data)
 
     switch (device)
     {
+    case CASIC::Name::Mercury:
+        Render3D->SetBlockCulling((data & 4) == 4);
+        break;
     case CASIC::Name::Mars:
         Render3D->SetSunClamp((data & 0x40000) == 0);
         break;

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1518,6 +1518,7 @@ static Util::Config::Node DefaultConfig()
   config.Set("ShowFrameRate", false);
   config.Set("Crosshairs", int(0));
   config.Set("CrosshairStyle", "vector");
+  config.Set("NoWhiteFlash", false);
   config.Set("FlipStereo", false);
 #ifdef SUPERMODEL_WIN32
   config.Set("InputSystem", "dinput");
@@ -1612,6 +1613,7 @@ static void Help(void)
   puts("  -legacy3d               Legacy 3D engine (faster but less accurate)");
   puts("  -multi-texture          Use 8 texture maps for decoding (legacy engine)");
   puts("  -no-multi-texture       Decode to single texture (legacy engine) [Default]");
+  puts("  -no-white-flash         Disables white flash when games disable 3D rendering");
   puts("  -vert-shader=<file>     Load Real3D vertex shader for 3D rendering");
   puts("  -frag-shader=<file>     Load Real3D fragment shader for 3D rendering");
   puts("  -vert-shader-fog=<file> Load Real3D scroll fog vertex shader (new engine)");
@@ -1748,6 +1750,8 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
     { "-no-dsb",              { "EmulateDSB",       false } },
     { "-legacy-scsp",         { "LegacySoundDSP",   true } },
     { "-new-scsp",            { "LegacySoundDSP",   false } },
+    { "-no-white-flash",      { "NoWhiteFlash",     true } },
+    { "-white-flash",         { "NoWhiteFlash",     false } },
 #ifdef NET_BOARD
     { "-net",                 { "Network",       true } },
     { "-no-net",              { "Network",       false } },


### PR DESCRIPTION
Disables 3D rendering and clears screen to white. Only implemented in new 3D renderer for now, though it could easily be added to the legacy 3D renderer if desired.

I added an option to turn this off if desired; set NoWhiteFlash to true in Supermodel.ini or add -no-white-flash to command line.