### PR TITLE
sdl: add support for gamecontroller api

### DIFF
--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -2106,7 +2106,9 @@ int main(int argc, char **argv)
 
   // Create input system
   if (selectedInputSystem == "sdl")
-    InputSystem = new CSDLInputSystem(s_runtime_config);
+    InputSystem = new CSDLInputSystem(s_runtime_config, false);
+  else if (selectedInputSystem == "sdlgamepad")
+    InputSystem = new CSDLInputSystem(s_runtime_config, true);
 #ifdef SUPERMODEL_WIN32
   else if (selectedInputSystem == "dinput")
     InputSystem = new CDirectInputSystem(s_runtime_config, s_window, false, false);

--- a/Src/OSD/SDL/SDLInputSystem.h
+++ b/Src/OSD/SDL/SDLInputSystem.h
@@ -51,11 +51,17 @@ class CSDLInputSystem : public CInputSystem
 private:
 	const Util::Config::Node& m_config;
 
+	// use gamecontroller api
+	bool m_useGameController;
+
 	// Lookup table to map key names to SDLKeys
 	static SDLKeyMapStruct s_keyMap[];
 
 	// Vector to keep track of attached joysticks
 	std::vector<SDL_Joystick*> m_joysticks;
+
+	// Vector to keep track of attached gamepads
+	std::vector<SDL_GameController*> m_gamepads;
 
 	// Vector of joystick details
 	std::vector<JoyDetails> m_joyDetails;
@@ -146,7 +152,7 @@ public:
 	/*
 	 * Constructs an SDL input system.
 	 */
-	CSDLInputSystem(const Util::Config::Node& config);
+	CSDLInputSystem(const Util::Config::Node& config, bool useGameController);
 
 	~CSDLInputSystem();
 


### PR DESCRIPTION
currently, supermodel only implement the sdl joystick api.

That mean that if we use different controllers, they need to be correctly remapped && calibrate each time.

This patch implement sdl gamecontroller api, through "InputSystem = sdlgamepad" config which normalize the mapping && calibration.

gamecontroller is matching x-input on windows, so the limit is 6 axis (with 2 separated Z triggers axis), 4 dpad/hats and 16 buttons. (x-input is limited to 10buttons).