### PR TITLE
Fixing tilegen bugs in Scud Race

### DIFF
--- a/Config/Games.xml
+++ b/Config/Games.xml
@@ -1438,10 +1438,6 @@
       </inputs>
     </hardware>
     <roms>
-      <patches>
-        <!-- Prevent "rolling start" scrolling glitch -->
-        <patch region="crom" bits="32" offset="0x14BDB8" value="0x20B201E0" />
-      </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-19691.20" crc32="0x83523B89" />
         <file offset="2" name="epr-19690.19" crc32="0x25F007FE" />
@@ -1530,8 +1526,6 @@
       <patches>
         <!-- Secret debug menu -->
         <patch region="crom" bits="32" offset="0x199DE8" value="0x00050208" />
-        <!-- Prevent "rolling start" scrolling glitch -->
-        <patch region="crom" bits="32" offset="0x14BDF4" value="0x20B201E0" />
       </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-19734.20" crc32="0xBE897336" />
@@ -1564,10 +1558,6 @@
       </inputs>
     </hardware>
     <roms>
-      <patches>
-        <!-- Prevent "rolling start" scrolling glitch -->
-        <patch region="crom" bits="32" offset="0x146350" value="0x20B201E0" />
-      </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-19607a.20" crc32="0x24301A12" />
         <file offset="2" name="epr-19608a.19" crc32="0x1426160E" />
@@ -1714,10 +1704,6 @@
       </inputs>
     </hardware>
     <roms>
-      <patches>
-        <!-- Prevent "rolling start" scrolling glitch -->
-        <patch region="crom" bits="32" offset="0x14E424" value="0x20B201E0" />
-      </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-20095a.20" crc32="0x58C7E393" />
         <file offset="2" name="epr-20094a.19" crc32="0xDBF17A43" />
@@ -1766,10 +1752,6 @@
       </inputs>
     </hardware>
     <roms>
-      <patches>
-        <!-- Prevent "rolling start" scrolling glitch -->
-        <patch region="crom" bits="32" offset="0x14E014" value="0x20B201E0" />
-      </patches>
       <region name="crom" stride="8" chunk_size="2" byte_swap="true">
         <file offset="0" name="epr-20095.20" crc32="0x44467BC1" />
         <file offset="2" name="epr-20094.19" crc32="0x299B6257" />

--- a/Src/Model3/TileGen.h
+++ b/Src/Model3/TileGen.h
@@ -290,25 +290,25 @@ private:
 
 	ColourOffsetRegister m_colourOffsetRegs[2];
 
-	bool	IsEnabled		(int layerNumber) const;
-	bool	Above3D			(int layerNumber) const;
-	bool	Is4Bit			(int layerNumber) const;
-	int		GetYScroll		(int layerNumber) const;
-	int		GetXScroll		(int layerNumber) const;
-	bool	LineScrollMode	(int layerNumber) const;
-	int		GetLineScroll	(int layerNumber, int yCoord) const;
-	int		GetTileNumber	(int xCoord, int yCoord, int xScroll, int yScroll) const;
-	int		GetTileData		(int layerNum, int tileNumber) const;
-	int		GetVFine		(int yCoord, int yScroll) const;
-	int		GetHFine		(int xCoord, int xScroll) const;
-	int		GetLineMask		(int layerNumber, int yCoord) const;
-	int		GetPixelMask	(int lineMask, int xCoord) const;
-	UINT32	GetColour32		(int layer, UINT32 data) const;
-	void	Draw4Bit		(int tileData, int hFine, int vFine, UINT32* const lineBuffer, const UINT32* const pal, int& x) const;
-	void	Draw8Bit		(int tileData, int hFine, int vFine, UINT32* const lineBuffer, const UINT32* const pal, int& x) const;
+	bool	IsEnabled			(int layerNumber) const;
+	bool	Above3D				(int layerNumber) const;
+	bool	Is4Bit				(int layerNumber) const;
+	int		GetYScroll			(int layerNumber) const;
+	int		GetXScroll			(int layerNumber) const;
+	bool	LineScrollMode		(int layerNumber) const;
+	int		GetLineScroll		(int layerNumber, int yCoord) const;
+	int		GetTilePairNumber	(int xCoord, int yCoord, int xScroll, int yScroll) const;
+	int		GetTileData			(int layerNum, int tilePairNumber) const;
+	int		GetVFine			(int yCoord, int yScroll) const;
+	int		GetHFine			(int xCoord, int xScroll) const;
+	int		GetLineMask			(int layerNumber, int yCoord) const;
+	int		GetPixelMask		(int lineMask, int xCoord) const;
+	UINT32	GetColour32			(int layer, UINT32 data) const;
+	void	Draw4BitTilePair	(int tileData, int hStart, int hEnd, int vFine, UINT32* const lineBuffer, const UINT32* const pal, int& x) const;
+	void	Draw8BitTilePair	(int tileData, int hStart, int hEnd, int vFine, UINT32* const lineBuffer, const UINT32* const pal, int& x) const;
 
-	void	WritePalette	(int layer, int address, UINT32 data);
-	void	RecomputePalettes(int layer);	// 0 = bottom, 1 = top
+	void	WritePalette		(int layer, int address, UINT32 data);
+	void	RecomputePalettes	(int layer);	// 0 = bottom, 1 = top
 
 	//const Util::Config::Node& m_config;
 	const bool m_gpuMultiThreaded;


### PR DESCRIPTION
Modified the tilegen code so that tiles are loaded in pairs, as they are on real hardware.

Fixed the long-standing "rolling start" glitch in all versions of Scud Race, and also a more recent sky background overdraw bug in credits of Super Beginner track in Scud Race Plus.

Removed "rolling start" patches from Scud Race ROMs since they are no longer needed