### PR TITLE
Common digital sensitivity and decay speed settings for all digital buttons mapped to analog inputs

### DIFF
--- a/Src/Inputs/InputSystem.cpp
+++ b/Src/Inputs/InputSystem.cpp
@@ -6,7 +6,7 @@
  ** This file is part of Supermodel.
  **
  ** Supermodel is free software: you can redistribute it and/or modify it under
- ** the terms of the GNU General Public License as published by the Free 
+ ** the terms of the GNU General Public License as published by the Free
  ** Software Foundation, either version 3 of the License, or (at your option)
  ** any later version.
  **
@@ -49,7 +49,7 @@ unsigned CInputSystem::totalSrcsAcquired = 0;
 unsigned CInputSystem::totalSrcsReleased = 0;
 #endif
 
-const char *CInputSystem::s_validKeyNames[] = 
+const char *CInputSystem::s_validKeyNames[] =
 {
   // General keys
   "BACKSPACE",
@@ -123,7 +123,7 @@ const char *CInputSystem::s_validKeyNames[] =
   "Y",
   "Z",
   "DEL",
-  
+
   // Keypad
   "KEYPAD0",
   "KEYPAD1",
@@ -142,7 +142,7 @@ const char *CInputSystem::s_validKeyNames[] =
   "KEYPADPLUS",
   "KEYPADENTER",
   "KEYPADEQUALS",
-  
+
   // Arrows + Home/End Pad
   "UP",
   "DOWN",
@@ -170,8 +170,8 @@ const char *CInputSystem::s_validKeyNames[] =
   "F13",
   "F14",
   "F15",
-    
-  // Modifier Keys  
+
+  // Modifier Keys
   "NUMLOCK",
   "CAPSLOCK",
   "SCROLLLOCK",
@@ -190,7 +190,7 @@ const char *CInputSystem::s_validKeyNames[] =
   "LEFTWINDOWS",
   "ALTGR",
   "COMPOSE",
-    
+
   // Other
   "HELP",
   "PRINT",
@@ -202,7 +202,7 @@ const char *CInputSystem::s_validKeyNames[] =
   "UNDO"
 };
 
-const MousePartsStruct CInputSystem::s_mseParts[] = 
+const MousePartsStruct CInputSystem::s_mseParts[] =
 {
   // X Axis (Axis 1)
   { "XAXIS",         MouseXAxis },
@@ -215,7 +215,7 @@ const MousePartsStruct CInputSystem::s_mseParts[] =
   { "AXIS1_INV",     MouseXAxisInv },
   { "AXIS1_POS",     MouseXAxisPos },
   { "AXIS1_NEG",     MouseXAxisNeg },
-  
+
   // Y Axis (Axis 2)
   { "YAXIS",         MouseYAxis },
   { "YAXIS_INV",     MouseYAxisInv },
@@ -258,7 +258,7 @@ const MousePartsStruct CInputSystem::s_mseParts[] =
   { NULL,            MouseUnknown }
 };
 
-const JoyPartsStruct CInputSystem::s_joyParts[] = 
+const JoyPartsStruct CInputSystem::s_joyParts[] =
 {
   // X-Axis (Axis 1)
   { "XAXIS",         JoyXAxis },
@@ -271,7 +271,7 @@ const JoyPartsStruct CInputSystem::s_joyParts[] =
   { "AXIS1_INV",     JoyXAxisInv },
   { "AXIS1_POS",     JoyXAxisPos },
   { "AXIS1_NEG",     JoyXAxisNeg },
-  
+
   // Y-Axis (Axis 2)
   { "YAXIS",         JoyYAxis },
   { "YAXIS_INV",     JoyYAxisInv },
@@ -283,7 +283,7 @@ const JoyPartsStruct CInputSystem::s_joyParts[] =
   { "AXIS2_INV",     JoyYAxisInv },
   { "AXIS2_POS",     JoyYAxisPos },
   { "AXIS2_NEG",     JoyYAxisNeg },
-  
+
   // Z-Axis (Axis 3)
   { "ZAXIS",         JoyZAxis },
   { "ZAXIS_INV",     JoyZAxisInv },
@@ -313,7 +313,7 @@ const JoyPartsStruct CInputSystem::s_joyParts[] =
   { "AXIS5_INV",     JoyRYAxisInv },
   { "AXIS5_POS",     JoyRYAxisPos },
   { "AXIS5_NEG",     JoyRYAxisNeg },
-  
+
   // RZ-Axis (Axis 6)
   { "RZAXIS",        JoyRZAxis },
   { "RZAXIS_INV",    JoyRZAxisInv },
@@ -428,6 +428,8 @@ CInputSystem::CInputSystem(const char *systemName)
     m_defKeySettings(),
     m_defMseSettings(),
     m_defJoySettings(),
+    m_digitalSensitivity(DEFAULT_DIGITAL_SENSITIVITY),
+    m_digitalDecaySpeed(DEFAULT_DIGITAL_DECAYSPEED),
     m_dispX(0),
     m_dispY(0),
     m_dispW(0),
@@ -492,7 +494,7 @@ void CInputSystem::CreateSourceCache()
       memset(m_joySources[joyNum], 0, sizeof(CInputSource*) * NUM_JOY_PARTS);
     }
   }
-} 
+}
 
 void CInputSystem::ClearSourceCache(bool deleteCache)
 {
@@ -584,7 +586,7 @@ void CInputSystem::ReleaseSource(CInputSource *&source)
     source->Release();
   source = NULL;
 }
-  
+
 CInputSource *CInputSystem::GetKeySource(int kbdNum, int keyIndex)
 {
   if (kbdNum == ANY_KEYBOARD)
@@ -695,7 +697,7 @@ void CInputSystem::CheckAllSources(unsigned readFlags, bool fullAxisOnly, bool &
     // For mouse input, wait until mouse is in centre of display before parsing X- and Y-axis movements
     if (!mseCentered)
       mseCentered = ConfigMouseCentered();
-  
+
     // Check all mouse sources for input, merging devices if required
     if ((readFlags & READ_MERGE_MOUSE) || m_numMice == ANY_MOUSE)
       CheckMouseSources(ANY_MOUSE, fullAxisOnly, mseCentered, sources, mapping, badSources);
@@ -705,7 +707,7 @@ void CInputSystem::CheckAllSources(unsigned readFlags, bool fullAxisOnly, bool &
         CheckMouseSources(mseNum, fullAxisOnly, mseCentered, sources, mapping, badSources);
     }
   }
-  
+
   // See if should read joysticks
   if (readFlags & READ_JOYSTICK)
   {
@@ -824,7 +826,7 @@ string CInputSystem::IntToString(int num)
 
 bool CInputSystem::EqualsIgnoreCase(const string& str1, const char *str2)
 {
-  for (string::const_iterator ci = str1.begin(); ci < str1.end(); ++ci) 
+  for (string::const_iterator ci = str1.begin(); ci < str1.end(); ++ci)
   {
     if (*str2 == '\0' || tolower(*ci) != tolower(*str2))
       return false;
@@ -835,7 +837,7 @@ bool CInputSystem::EqualsIgnoreCase(const string& str1, const char *str2)
 
 bool CInputSystem::StartsWithIgnoreCase(const string& str1, const char *str2)
 {
-  for (string::const_iterator ci = str1.begin(); ci < str1.end(); ++ci) 
+  for (string::const_iterator ci = str1.begin(); ci < str1.end(); ++ci)
   {
     if (*str2 == '\0')
       return true;
@@ -843,7 +845,7 @@ bool CInputSystem::StartsWithIgnoreCase(const string& str1, const char *str2)
       return false;
     str2++;
   }
-  return *str2 == '\0'; 
+  return *str2 == '\0';
 }
 
 bool CInputSystem::IsValidKeyName(const string& str)
@@ -998,7 +1000,7 @@ CInputSource *CInputSystem::ParseSingleSource(string str)
       return new CNegInputSource(source);
     else
       return source;
-  } 
+  }
 
   // Try parsing a key mapping
   int kbdNum;
@@ -1038,7 +1040,7 @@ CInputSource *CInputSystem::ParseSingleSource(string str)
       return m_emptySource;
     }
   }
-  
+
   // Try parsing a mouse mapping
   int mseNum;
   size_t msePartIndex = ParseDevMapping(str, "MOUSE", mseNum);
@@ -1061,7 +1063,7 @@ CInputSource *CInputSystem::ParseSingleSource(string str)
       return GetJoySource(joyNum, joyPart);
   }
 
-  // As last option, assume mapping is just a key name and try creating keyboard source from it (to retain compatibility with previous 
+  // As last option, assume mapping is just a key name and try creating keyboard source from it (to retain compatibility with previous
   // versions of Supermodel)
   if (IsValidKeyName(str))
   {
@@ -1075,6 +1077,26 @@ CInputSource *CInputSystem::ParseSingleSource(string str)
 
   // If got here, it was not possible to parse mapping string so return NULL
   return NULL;
+}
+
+void CInputSystem::PrintCommonSettings() const
+{
+  printf(" Sensitivity = %u %%\n", m_digitalSensitivity);
+  printf(" Decay Speed = %u %%\n", m_digitalDecaySpeed);
+}
+
+void CInputSystem::LoadCommonSettings(const Util::Config::Node &config)
+{
+  // Read from ini file
+  m_digitalSensitivity = config["InputDigitalSensitivity"].ValueAsDefault<unsigned>(DEFAULT_DIGITAL_SENSITIVITY);
+  m_digitalDecaySpeed = config["InputDigitalDecaySpeed"].ValueAsDefault<unsigned>(DEFAULT_DIGITAL_DECAYSPEED);
+}
+
+void CInputSystem::StoreCommonSettings(Util::Config::Node *config)
+{
+  // Always write these (no reason not to)
+  config->Set("InputDigitalSensitivity", m_digitalSensitivity);
+  config->Set("InputDigitalDecaySpeed", m_digitalDecaySpeed);
 }
 
 void CInputSystem::PrintKeySettings(int kbdNum, KeySettings *settings)
@@ -1101,11 +1123,23 @@ KeySettings *CInputSystem::LoadKeySettings(const Util::Config::Node &config, int
     settings->sensitivity = node->ValueAs<unsigned>();
     read |= true;
   }
+  else
+  {
+    // Use common digital sensitivity
+    settings->sensitivity = m_digitalSensitivity;
+    read |= (settings->sensitivity != common->sensitivity); // unfortunately, this will cause the keyboard sensitivity setting to be written to INI if it differs from the default one, despite it coming from the universal setting
+  }
   node = config.TryGet(baseKey + "DecaySpeed");
   if (node)
   {
     settings->decaySpeed = node->ValueAs<unsigned>();
     read |= true;
+  }
+  else
+  {
+    // Use common digital decay speed
+    settings->decaySpeed = m_digitalDecaySpeed;
+    read |= (settings->decaySpeed != common->decaySpeed);
   }
   if (read)
     return settings;
@@ -1154,7 +1188,7 @@ MouseSettings *CInputSystem::LoadMouseSettings(const Util::Config::Node &config,
       settings->deadZones[axisNum] = node->ValueAs<unsigned>();
       read |= true;
     }
-  
+
   }
   if (read)
     return settings;
@@ -1166,14 +1200,14 @@ void CInputSystem::StoreMouseSettings(Util::Config::Node *config, MouseSettings 
 {
   // Get common mouse settings
   MouseSettings *common = (settings->mseNum != ANY_MOUSE ? GetMouseSettings(ANY_MOUSE, true) : &m_defMseSettings);
-  
+
   // Write to ini file any settings that are different to common/default settings
   string baseKey("InputMouse");
   if (settings->mseNum != ANY_MOUSE)
     baseKey.append(IntToString(settings->mseNum + 1));
   for (int axisNum = 0; axisNum < NUM_MOUSE_AXES; axisNum++)
   {
-    if (settings->deadZones[axisNum] != common->deadZones[axisNum]) 
+    if (settings->deadZones[axisNum] != common->deadZones[axisNum])
       config->Set(baseKey + s_axisIds[axisNum] + "DeadZone", settings->deadZones[axisNum]);
   }
 }
@@ -1182,7 +1216,7 @@ void CInputSystem::PrintJoySettings(int joyNum, JoySettings *settings)
 {
   const JoyDetails *joyDetails = (joyNum != ANY_JOYSTICK ? GetJoyDetails(joyNum) : NULL);
   for (int axisNum = 0; axisNum < NUM_JOY_AXES; axisNum++)
-  { 
+  {
     if (joyDetails && !joyDetails->hasAxis[axisNum])
       continue;
     const char *axisName = s_axisNames[axisNum];
@@ -1260,13 +1294,13 @@ void CInputSystem::StoreJoySettings(Util::Config::Node *config, JoySettings *set
     const char *axisId = s_axisIds[axisNum];
     if (settings->axisMinVals[axisNum] != common->axisMinVals[axisNum])
       config->Set(baseKey + axisId + "MinVal", settings->axisMinVals[axisNum]);
-    if (settings->axisOffVals[axisNum] != common->axisOffVals[axisNum]) 
+    if (settings->axisOffVals[axisNum] != common->axisOffVals[axisNum])
       config->Set(baseKey + axisId + "OffVal", settings->axisOffVals[axisNum]);
     if (settings->axisMaxVals[axisNum] != common->axisMaxVals[axisNum])
       config->Set(baseKey + axisId + "MaxVal", settings->axisMaxVals[axisNum]);
-    if (settings->deadZones[axisNum] != common->deadZones[axisNum]) 
+    if (settings->deadZones[axisNum] != common->deadZones[axisNum])
       config->Set(baseKey + axisId + "DeadZone", settings->deadZones[axisNum]);
-    if (settings->saturations[axisNum] != common->saturations[axisNum]) 
+    if (settings->saturations[axisNum] != common->saturations[axisNum])
       config->Set(baseKey + axisId + "Saturation", settings->saturations[axisNum]);
   }
 }
@@ -1358,7 +1392,7 @@ EMousePart CInputSystem::GetMouseButton(int butNum)
 {
   if (butNum < 0 || butNum >= NUM_MOUSE_BUTTONS)
     return MouseUnknown;
-  return (EMousePart)(MouseButtonLeft + butNum);  
+  return (EMousePart)(MouseButtonLeft + butNum);
 }
 
 bool CInputSystem::IsAxis(EJoyPart joyPart)
@@ -1429,7 +1463,7 @@ EJoyPart CInputSystem::GetJoyButton(int butNum)
 {
   if (butNum < 0 || butNum >= NUM_JOY_BUTTONS)
     return JoyUnknown;
-  return (EJoyPart)(JoyButton0 + butNum); 
+  return (EJoyPart)(JoyButton0 + butNum);
 }
 
 bool CInputSystem::ConfigMouseCentered()
@@ -1437,12 +1471,12 @@ bool CInputSystem::ConfigMouseCentered()
   // Get mouse X & Y
   int mx = GetMouseAxisValue(ANY_MOUSE, AXIS_X);
   int my = GetMouseAxisValue(ANY_MOUSE, AXIS_Y);
-  
+
   // See if mouse in center of display
   unsigned lx = m_dispX + m_dispW / 4;
   unsigned ly = m_dispY + m_dispH / 4;
   return mx >= (int)lx && mx <= (int)(lx + m_dispW / 2) && my >= (int)ly && my <= (int)(ly + m_dispH / 2);
-} 
+}
 
 CInputSource *CInputSystem::CreateAnyKeySource(int keyIndex)
 {
@@ -1511,7 +1545,7 @@ CInputSource *CInputSystem::CreateMouseSource(int mseNum, EMousePart msePart)
     int butNum = GetButtonNumber(msePart);
     if (butNum < 0)
       return NULL;  // Buttons out of range are invalid
-    return new CMseButInputSource(this, mseNum, butNum);
+    return new CMseButInputSource(this, mseNum, butNum, m_digitalSensitivity, m_digitalDecaySpeed);
   }
 
   // If got here, then mouse part is invalid
@@ -1523,7 +1557,7 @@ CInputSource *CInputSystem::CreateJoySource(int joyNum, EJoyPart joyPart)
   // Get joystick details and settings
   const JoyDetails *joyDetails = GetJoyDetails(joyNum);
   JoySettings *settings = GetJoySettings(joyNum, true);
-  
+
   // Create source according to given joystick part
   int axisNum;
   int axisDir;
@@ -1535,7 +1569,7 @@ CInputSource *CInputSystem::CreateJoySource(int joyNum, EJoyPart joyPart)
     if (!joyDetails->hasAxis[axisNum])
       return m_emptySource;  // If joystick doesn't have axis, then return empty source rather than NULL as not really an error
     // Otherwise, create axis source with appropriate axis range, deadzone and saturation settings
-    return new CJoyAxisInputSource(this, joyNum, axisNum, axisDir, 
+    return new CJoyAxisInputSource(this, joyNum, axisNum, axisDir,
       settings->axisMinVals[axisNum], settings->axisOffVals[axisNum], settings->axisMaxVals[axisNum],
       settings->deadZones[axisNum], settings->saturations[axisNum]);
   }
@@ -1544,19 +1578,19 @@ CInputSource *CInputSystem::CreateJoySource(int joyNum, EJoyPart joyPart)
     // Part is joystick POV hat controller so see whether joystick has this POV
     if (povNum >= joyDetails->numPOVs)
       return m_emptySource;  // If joystick doesn't have POV, then return empty source rather than NULL as not really an error
-    return new CJoyPOVInputSource(this, joyNum, povNum, povDir);
+    return new CJoyPOVInputSource(this, joyNum, povNum, povDir, m_digitalSensitivity, m_digitalDecaySpeed);
   }
   else if (IsButton(joyPart))
-  { 
+  {
     // Part is joystick button so map it to a button number
     int butNum = GetButtonNumber(joyPart);
     if (butNum < 0 || butNum >= NUM_JOY_BUTTONS)
       return NULL;  // Buttons out of range are invalid
     if (butNum >= joyDetails->numButtons)
       return m_emptySource;  // If joystick doesn't have button, then return empty source rather than NULL as not really an error
-    return new CJoyButInputSource(this, joyNum, butNum);
+    return new CJoyButInputSource(this, joyNum, butNum, m_digitalSensitivity, m_digitalDecaySpeed);
   }
-  
+
   // If got here, then joystick part is invalid
   return NULL;
 }
@@ -1625,6 +1659,10 @@ void CInputSystem::PrintSettings()
 
   puts("");
 
+  // Print all common settings
+  puts("Common Settings:");
+  PrintCommonSettings();
+
   // Print all key settings for attached keyboards
   KeySettings *keySettings;
   if (m_numKbds == ANY_KEYBOARD)
@@ -1687,6 +1725,9 @@ void CInputSystem::LoadFromConfig(const Util::Config::Node &config)
   ClearSettings();
   ClearSourceCache();
 
+  // Read settings that are not bound to specific input device instances
+  LoadCommonSettings(config);
+
   // Read all key settings for attached keyboards
   KeySettings *keySettings = LoadKeySettings(config, ANY_KEYBOARD);
   if (keySettings != NULL)
@@ -1723,6 +1764,9 @@ void CInputSystem::LoadFromConfig(const Util::Config::Node &config)
 
 void CInputSystem::StoreToConfig(Util::Config::Node *config)
 {
+  // Store universal settings
+  StoreCommonSettings(config);
+
   // Write all key settings
   for (vector<KeySettings*>::iterator it = m_keySettings.begin(); it != m_keySettings.end(); ++it)
     StoreKeySettings(config, *it);
@@ -1803,7 +1847,7 @@ bool CInputSystem::ReadMapping(char *buffer, unsigned bufSize, bool fullAxisOnly
         mapping.clear();
         sources.clear();
         mseCentered = false;
-      } 
+      }
     }
 
     // Don't poll continuously
@@ -1884,10 +1928,10 @@ bool CInputSystem::DetectJoystickAxis(unsigned joyNum, unsigned &axisNum, const 
     maxVals[loopAxisNum] = joyVal;
   }
   for (;;)
-  { 
+  {
     if (!Poll())
       goto Cancelled;
-    
+
     // Check if escape source was triggered
     if (escape && escape->IsActive())
     {
@@ -1965,8 +2009,8 @@ bool CInputSystem::DetectJoystickAxis(unsigned joyNum, unsigned &axisNum, const 
     cancelled = true;
     puts("Not Detected");
   }
-  goto Finish;  
-  
+  goto Finish;
+
 Cancelled:
   puts("[Cancelled]");
   cancelled = true;
@@ -2001,12 +2045,12 @@ bool CInputSystem::CalibrateJoystickAxis(unsigned joyNum, unsigned axisNum, cons
 
 Repeat:
   printf("Calibrating %s of joystick '%s'.\n\n", joyDetails->axisName[axisNum], joyDetails->name);
-  
+
   unsigned totalRange;
   unsigned posDeadZone;
   unsigned negDeadZone;
   unsigned deadZone;
-      
+
   int posVal = 0;
   int negVal = 0;
   int offVal = 0;
@@ -2019,7 +2063,7 @@ Repeat:
   {
     switch (step)
     {
-      case 0: 
+      case 0:
         puts("Step 1:");
         puts(" Move axis now to its furthest positive/'on' position and hold, ie:");
         if (axisNum == AXIS_X || axisNum == AXIS_RX || axisNum == AXIS_Z || axisNum == AXIS_RZ)
@@ -2031,7 +2075,7 @@ Repeat:
         puts(" - for a steering wheel, turn it all the way to the right.");
         puts(" - for a pedal, press it all the way to the floor.");
         break;
-      case 1: 
+      case 1:
         puts("Step 2:");
         puts(" Move axis the other way to its furthest negative position and hold, ie:");
         if (axisNum == AXIS_X || axisNum == AXIS_RX || axisNum == AXIS_Z || axisNum == AXIS_RZ)
@@ -2044,7 +2088,7 @@ Repeat:
         puts(" - for a pedal, let go of the pedal completely.  If there is another pedal");
         puts("   that shares the same axis then press that one all the way to the floor.");
         break;
-      case 2: 
+      case 2:
         puts("Step 3:");
         puts(" Return axis to its central/'off' position and hold, ie:");
         if (axisNum == AXIS_X || axisNum == AXIS_RX || axisNum == AXIS_Y || axisNum == AXIS_RY || axisNum == AXIS_Z || axisNum == AXIS_RZ)
@@ -2077,7 +2121,7 @@ Repeat:
     int maxVal = joyVal;
     bool firstOut = true;
     for (unsigned frames = 0; frames < 3 * 60; frames++)
-    { 
+    {
       if (!Poll())
         goto Cancelled;
 
@@ -2117,7 +2161,7 @@ Repeat:
     {
       case 0: posVal = (abs(maxVal) >= abs(minVal) ? maxVal : minVal); break;
       case 1: negVal = (abs(minVal) >= abs(maxVal) ? minVal : maxVal); break;
-      case 2: 
+      case 2:
         if (minVal <= 0 && maxVal >= 0)
           offVal = 0;
         else if (minVal == DEFAULT_JOY_AXISMINVAL)
@@ -2133,12 +2177,12 @@ Repeat:
         break;
     }
   }
-  
+
   totalRange = posRange + negRange;
   posDeadZone = (unsigned)ceil(100.0 * (double)posOffRange / (double)posRange);
   negDeadZone = (unsigned)ceil(100.0 * (double)negOffRange / (double)negRange);
   deadZone = max<unsigned>(1, max<unsigned>(negDeadZone, posDeadZone));
-    
+
   bool okay;
   if (posVal > negVal)
     okay = negVal <= offVal && offVal <= posVal && totalRange > 3000 && deadZone < 90;
@@ -2162,7 +2206,7 @@ Repeat:
     printf(" Dead Zone        = %u %%\n", deadZone);
     printf("\nAccept these settings: y/n? ");
     fflush(stdout); // required on terminals that use buffering
-    
+
     // Loop until user confirms or declines
     while (ReadMapping(mapping, 50, false, READ_KEYBOARD|READ_MERGE, escapeMapping))
     {
@@ -2174,11 +2218,11 @@ Repeat:
         joySettings->axisMaxVals[axisNum] = posVal;
         joySettings->axisOffVals[axisNum] = offVal;
         joySettings->deadZones[axisNum] = deadZone;
-        
+
         ClearSourceCache();
 
         puts("Accepted");
-        goto Finish;    
+        goto Finish;
       }
     }
     goto Cancelled;
@@ -2189,7 +2233,7 @@ Repeat:
     puts("were not followed correctly or the joystick is sending invalid data.");
     printf("\nTry calibrating again: y/n? ");
     fflush(stdout); // required on terminals that use buffering
-    
+
     // Loop until user confirms or declines
     while (ReadMapping(mapping, 50, false, READ_KEYBOARD|READ_MERGE, escapeMapping))
     {
@@ -2203,7 +2247,7 @@ Repeat:
     }
     goto Cancelled;
   }
-  
+
 Cancelled:
   puts("[Cancelled]");
   cancelled = true;
@@ -2267,8 +2311,8 @@ void CInputSystem::PrintDevices()
 /*
  * CInputSystem::CKeyInputSource
  */
-CInputSystem::CKeyInputSource::CKeyInputSource(CInputSystem *system, int kbdNum, int keyIndex, unsigned sensitivity, unsigned decaySpeed) : 
-  CInputSource(SourceSwitch), m_system(system), m_kbdNum(kbdNum), m_keyIndex(keyIndex), m_val(0) 
+CInputSystem::CKeyInputSource::CKeyInputSource(CInputSystem *system, int kbdNum, int keyIndex, unsigned sensitivity, unsigned decaySpeed) :
+  CInputSource(SourceSwitch), m_system(system), m_kbdNum(kbdNum), m_keyIndex(keyIndex), m_val(0)
 {
   // Calculate max value and incr and decr values (sensitivity is given as percentage 1-100, with 100 being most sensitive, and
   // decay speed given as percentage 1-200 of attack speed)
@@ -2301,8 +2345,8 @@ bool CInputSystem::CKeyInputSource::GetValueAsAnalog(int &val, int minVal, int o
 /*
  * CInputSystem::CMseAxisInputSource
  */
-CInputSystem::CMseAxisInputSource::CMseAxisInputSource(CInputSystem *system, int mseNum, int axisNum, int axisDir, unsigned deadZone) : 
-  CInputSource(axisDir == AXIS_FULL || axisDir == AXIS_INVERTED ? SourceFullAxis : SourceHalfAxis), 
+CInputSystem::CMseAxisInputSource::CMseAxisInputSource(CInputSystem *system, int mseNum, int axisNum, int axisDir, unsigned deadZone) :
+  CInputSource(axisDir == AXIS_FULL || axisDir == AXIS_INVERTED ? SourceFullAxis : SourceHalfAxis),
   m_system(system), m_mseNum(mseNum), m_axisNum(axisNum), m_axisDir(axisDir)
 {
   // If X- or Y-axis then calculate size of dead pixels region in centre of display (deadzone is given as a percentage 0-99)
@@ -2387,10 +2431,15 @@ bool CInputSystem::CMseAxisInputSource::GetValueAsAnalog(int &val, int minVal, i
 /*
  * CInputSystem::CMseButInputSource
  */
-CInputSystem::CMseButInputSource::CMseButInputSource(CInputSystem *system, int mseNum, int butNum) :
-  CInputSource(SourceSwitch), m_system(system), m_mseNum(mseNum), m_butNum(butNum)
+CInputSystem::CMseButInputSource::CMseButInputSource(CInputSystem *system, int mseNum, int butNum, unsigned sensitivity, unsigned decaySpeed) :
+  CInputSource(SourceSwitch), m_system(system), m_mseNum(mseNum), m_butNum(butNum), m_val(0)
 {
-  //
+  // Calculate max value and incr and decr values (sensitivity is given as percentage 1-100, with 100 being most sensitive, and
+  // decay speed given as percentage 1-200 of attack speed)
+  int s = Clamp((int)sensitivity, 1, 100);
+  int d = Clamp((int)decaySpeed, 1, 200);
+  m_incr = 100 * s;
+  m_decr = d * s;
 }
 
 bool CInputSystem::CMseButInputSource::GetValueAsSwitch(bool &val) const
@@ -2403,9 +2452,13 @@ bool CInputSystem::CMseButInputSource::GetValueAsSwitch(bool &val) const
 
 bool CInputSystem::CMseButInputSource::GetValueAsAnalog(int &val, int minVal, int offVal, int maxVal)
 {
-  if (!m_system->IsMouseButPressed(m_mseNum, m_butNum))
+  if (m_system->IsMouseButPressed(m_mseNum, m_butNum))
+    m_val = min<int>(m_maxVal, m_val + m_incr);
+  else
+    m_val = max<int>(0, m_val - m_decr);
+  if (m_val == 0)
     return false;
-  val = maxVal;
+  val = Scale(m_val, 0, 0, m_maxVal, minVal, offVal, maxVal);
   return true;
 }
 
@@ -2413,7 +2466,7 @@ bool CInputSystem::CMseButInputSource::GetValueAsAnalog(int &val, int minVal, in
  * CInputSystem::CJoyAxisInputSource
  */
 CInputSystem::CJoyAxisInputSource::CJoyAxisInputSource(CInputSystem *system, int joyNum, int axisNum, int axisDir,
-  int axisMinVal, int axisOffVal, int axisMaxVal, unsigned deadZone, unsigned saturation) : 
+  int axisMinVal, int axisOffVal, int axisMaxVal, unsigned deadZone, unsigned saturation) :
   CInputSource(axisDir == AXIS_FULL || axisDir == AXIS_INVERTED ? SourceFullAxis : SourceHalfAxis),
   m_system(system), m_joyNum(joyNum), m_axisNum(axisNum), m_axisDir(axisDir), m_axisMinVal(axisMinVal), m_axisOffVal(axisOffVal), m_axisMaxVal(axisMaxVal)
 {
@@ -2481,10 +2534,15 @@ bool CInputSystem::CJoyAxisInputSource::SendForceFeedbackCmd(ForceFeedbackCmd ff
 /*
  * CInputSystem::CJoyPOVInputSource
  */
-CInputSystem::CJoyPOVInputSource::CJoyPOVInputSource(CInputSystem *system, int joyNum, int povNum, int povDir) :
-  CInputSource(SourceSwitch), m_system(system), m_joyNum(joyNum), m_povNum(povNum), m_povDir(povDir)
+CInputSystem::CJoyPOVInputSource::CJoyPOVInputSource(CInputSystem *system, int joyNum, int povNum, int povDir, unsigned sensitivity, unsigned decaySpeed) :
+  CInputSource(SourceSwitch), m_system(system), m_joyNum(joyNum), m_povNum(povNum), m_povDir(povDir), m_val(0)
 {
-  //
+  // Calculate max value and incr and decr values (sensitivity is given as percentage 1-100, with 100 being most sensitive, and
+  // decay speed given as percentage 1-200 of attack speed)
+  int s = Clamp((int)sensitivity, 1, 100);
+  int d = Clamp((int)decaySpeed, 1, 200);
+  m_incr = 100 * s;
+  m_decr = d * s;
 }
 
 bool CInputSystem::CJoyPOVInputSource::GetValueAsSwitch(bool &val) const
@@ -2497,19 +2555,28 @@ bool CInputSystem::CJoyPOVInputSource::GetValueAsSwitch(bool &val) const
 
 bool CInputSystem::CJoyPOVInputSource::GetValueAsAnalog(int &val, int minVal, int offVal, int maxVal)
 {
-  if (!m_system->IsJoyPOVInDir(m_joyNum, m_povNum, m_povDir))
+  if (m_system->IsJoyPOVInDir(m_joyNum, m_povNum, m_povDir))
+    m_val = min<int>(m_maxVal, m_val + m_incr);
+  else
+    m_val = max<int>(0, m_val - m_decr);
+  if (m_val == 0)
     return false;
-  val = maxVal;
+  val = Scale(m_val, 0, 0, m_maxVal, minVal, offVal, maxVal);
   return true;
 }
-  
+
 /*
  * CInputSystem::CJoyButInputSource
  */
-CInputSystem::CJoyButInputSource::CJoyButInputSource(CInputSystem *system, int joyNum, int butNum) :
-  CInputSource(SourceSwitch), m_system(system), m_joyNum(joyNum), m_butNum(butNum)
+CInputSystem::CJoyButInputSource::CJoyButInputSource(CInputSystem *system, int joyNum, int butNum, unsigned sensitivity, unsigned decaySpeed) :
+  CInputSource(SourceSwitch), m_system(system), m_joyNum(joyNum), m_butNum(butNum), m_val(0)
 {
-  //
+  // Calculate max value and incr and decr values (sensitivity is given as percentage 1-100, with 100 being most sensitive, and
+  // decay speed given as percentage 1-200 of attack speed)
+  int s = Clamp((int)sensitivity, 1, 100);
+  int d = Clamp((int)decaySpeed, 1, 200);
+  m_incr = 100 * s;
+  m_decr = d * s;
 }
 
 bool CInputSystem::CJoyButInputSource::GetValueAsSwitch(bool &val) const
@@ -2522,8 +2589,12 @@ bool CInputSystem::CJoyButInputSource::GetValueAsSwitch(bool &val) const
 
 bool CInputSystem::CJoyButInputSource::GetValueAsAnalog(int &val, int minVal, int offVal, int maxVal)
 {
-  if (!m_system->IsJoyButPressed(m_joyNum, m_butNum))
+  if (m_system->IsJoyButPressed(m_joyNum, m_butNum))
+    m_val = min<int>(m_maxVal, m_val + m_incr);
+  else
+    m_val = max<int>(0, m_val - m_decr);
+  if (m_val == 0)
     return false;
-  val = maxVal;
+  val = Scale(m_val, 0, 0, m_maxVal, minVal, offVal, maxVal);
   return true;
 }

--- a/Src/Inputs/InputSystem.h
+++ b/Src/Inputs/InputSystem.h
@@ -6,7 +6,7 @@
  ** This file is part of Supermodel.
  **
  ** Supermodel is free software: you can redistribute it and/or modify it under
- ** the terms of the GNU General Public License as published by the Free 
+ ** the terms of the GNU General Public License as published by the Free
  ** Software Foundation, either version 3 of the License, or (at your option)
  ** any later version.
  **
@@ -22,10 +22,10 @@
 /*
  * InputSystem.h
  *
- * Header file for CInputSystem. Defines the base class for an input system, 
+ * Header file for CInputSystem. Defines the base class for an input system,
  * the interface between the OS-independent and OS-dependent code.
  */
- 
+
 #ifndef INCLUDED_INPUTSYSTEM_H
 #define INCLUDED_INPUTSYSTEM_H
 
@@ -56,8 +56,8 @@ class CInputSource;
 #define ANY_JOYSTICK -1
 
 // Default keyboard, mouse and joystick settings
-#define DEFAULT_KEY_SENSITIVITY 25
-#define DEFAULT_KEY_DECAYSPEED 50
+#define DEFAULT_DIGITAL_SENSITIVITY 25
+#define DEFAULT_DIGITAL_DECAYSPEED 50
 #define DEFAULT_MSE_DEADZONE 0
 #define DEFAULT_JOY_AXISMINVAL -32768
 #define DEFAULT_JOY_AXISOFFVAL 0
@@ -99,7 +99,7 @@ class CInputSource;
 
 /*
  * Enumeration of all recognised mouse parts
- */ 
+ */
 enum EMousePart
 {
   MouseUnknown = -1,
@@ -228,17 +228,17 @@ struct JoyPartsStruct
 struct KeySettings
 {
   int kbdNum;             // Keyboard number (or ANY_KEYBOARD for settings that apply to all keyboards)
-  unsigned sensitivity;   // Key sensitivity for analog controls as percentage 1-100, where 100 is extremely responsive 
+  unsigned sensitivity;   // Key sensitivity for analog controls as percentage 1-100, where 100 is extremely responsive
     unsigned decaySpeed;    // Decay speed as percentage 1-200 of on speed
-  
+
   /*
    * Creates a KeySettings with default settings
    */
   KeySettings()
   {
     kbdNum = ANY_KEYBOARD;
-    sensitivity = DEFAULT_KEY_SENSITIVITY;
-    decaySpeed = DEFAULT_KEY_DECAYSPEED;
+    sensitivity = DEFAULT_DIGITAL_SENSITIVITY;
+    decaySpeed = DEFAULT_DIGITAL_DECAYSPEED;
   }
 };
 
@@ -315,11 +315,11 @@ struct JoyDetails
 };
 
 /*
- * Abstract base class that represents an input system.  An input system encapsulates all the O/S dependent code to read keyboards, 
+ * Abstract base class that represents an input system.  An input system encapsulates all the O/S dependent code to read keyboards,
  * mice and joysticks.
  */
 class CInputSystem
-{ 
+{
 private:
   // Array of valid key names
   static const char *s_validKeyNames[];
@@ -343,10 +343,10 @@ private:
   CInputSource **m_anyKeySources;
   CInputSource **m_anyMseSources;
   CInputSource **m_anyJoySources;
-  CInputSource ***m_keySources; 
+  CInputSource ***m_keySources;
   CInputSource ***m_mseSources;
   CInputSource ***m_joySources;
-  
+
   // Default key, mouse and joystick settings
   KeySettings m_defKeySettings;
   MouseSettings m_defMseSettings;
@@ -359,6 +359,10 @@ private:
 
   // Empty input source
   CMultiInputSource *m_emptySource;
+
+  // Common settings (not bound to any specific input device instance)
+  unsigned m_digitalSensitivity;
+  unsigned m_digitalDecaySpeed;
 
   //
   // Helper methods
@@ -374,11 +378,11 @@ private:
    */
   void ClearSourceCache(bool deleteCache = false);
 
-  /* 
+  /*
    * Releases a source from the cache.
-   */ 
+   */
   void ReleaseSource(CInputSource *&source);
-  
+
   /*
    * Returns a key source for the given keyboard number (or all keyboards if ANY_KEYBOARD supplied) and key index.
    * Will check the source cache first and if not found will create the source with CreateAnyKeySource or CreateKeySource.
@@ -456,7 +460,7 @@ private:
   static size_t ParseDevMapping(const std::string& str, const char *devType, int &devNum);
 
   /*
-   * Parses the given mapping string, possibly representing more than one mapping, and returns an input source for it or NULL if the 
+   * Parses the given mapping string, possibly representing more than one mapping, and returns an input source for it or NULL if the
    * mapping is invalid.
    * If fullAxisOnly is true, then only mappings that represent a full axis range (eg MouseXAxis) are parsed.
    */
@@ -466,6 +470,21 @@ private:
    * Parses the given single mapping string and returns an input source for it, or NULL if non exists.
    */
   CInputSource* ParseSingleSource(std::string str);
+
+  /*
+   * Prints common (i.e., independent of any particular device) settings to stdout.
+   */
+  void PrintCommonSettings() const;
+
+  /*
+   * Reads common settings from INI file.
+   */
+  void LoadCommonSettings(const Util::Config::Node &config);
+
+  /*
+   * Writes common settings to INI file.
+   */
+  void StoreCommonSettings(Util::Config::Node *config);
 
   /*
    * Prints the given key settings to stdout.
@@ -498,7 +517,7 @@ private:
    * Stores the given mouse settings to a config object, only storing settings that differ from their defaults.
    */
   void StoreMouseSettings(Util::Config::Node *config, MouseSettings *settings);
-  
+
   /*
    * Prints the given joystick settings to stdout.
    */
@@ -520,7 +539,7 @@ protected:
   unsigned m_dispX;
   unsigned m_dispY;
   unsigned m_dispW;
-  unsigned m_dispH; 
+  unsigned m_dispH;
 
   // Flag to indicate if system has grabbed mouse
   bool m_grabMouse;
@@ -558,8 +577,8 @@ protected:
    */
   static int GetButtonNumber(EMousePart msePart);
 
-  /* 
-   * Returns the EMousePart that represents the axis component for the given axis number (AXIS_X, AXIS_Y or AXIS_Z) and direction 
+  /*
+   * Returns the EMousePart that represents the axis component for the given axis number (AXIS_X, AXIS_Y or AXIS_Z) and direction
    * (AXIS_FULL, AXIS_INVERTED, AXIS_POS or AXIS_POS), or MouseUnknown otherwise.
    */
   static EMousePart GetMouseAxis(int axisNum, int axisDir);
@@ -594,7 +613,7 @@ protected:
 
   /*
    * Returns true if the given EJoyPart represents a POV hat direction, eg JoyPOV0Left.
-   */ 
+   */
   static bool IsPOV(EJoyPart joyPart);
 
   /*
@@ -614,14 +633,14 @@ protected:
    */
   static int GetButtonNumber(EJoyPart joyPart);
 
-  /* 
+  /*
    * Returns the EJoyPart that represents the axis component for the given axis number (AXIS_X, AXIS_Y, AXIS_Z, AXIS_RX, AXIS_RY or AXIS_RZ) and
    * direction (AXIS_FULL, AXIS_INVERTED, AXIS_POS or AXIS_POS), or JoyUnknown otherwise.
    */
   static EJoyPart GetJoyAxis(int axisNum, int axisDir);
 
   /*
-   * Returns the EJoyPart that represents the POV hot direction for the given POV number (0-4) and direction (POV_UP, POV_DOWN, 
+   * Returns the EJoyPart that represents the POV hot direction for the given POV number (0-4) and direction (POV_UP, POV_DOWN,
    * POV_LEFT or POV_RIGHT), JoyUnknown otherwise.
    */
   static EJoyPart GetJoyPOV(int povNum, int povDir);
@@ -647,7 +666,7 @@ protected:
    */
   virtual const char *GetKeyName(int keyIndex) = 0;
 
-  /* 
+  /*
    * Returns true if for the given keyboard the key with the system-specific key index is currently pressed.
    */
   virtual bool IsKeyPressed(int kbdNum, int keyIndex) const = 0;
@@ -711,7 +730,7 @@ protected:
    * Creates an input source combining all joysticks for the given EJoyPart.
    */
   virtual CInputSource *CreateAnyJoySource(EJoyPart joyPart);
-  
+
   /*
    * Creates an input source for the given keyboard number and key index.
    */
@@ -747,23 +766,23 @@ public:
 
   /*
    * Sets the current display geometry so that mouse movements can be scaled properly.
-   */ 
+   */
   void SetDisplayGeom(unsigned dispX, unsigned dispY, unsigned dispW, unsigned dispH);
 
   /*
-   * Returns the number of attached keyboards (or 0 if the system cannot handle keyboards at all or ANY_KEYBOARD if the system cannot 
+   * Returns the number of attached keyboards (or 0 if the system cannot handle keyboards at all or ANY_KEYBOARD if the system cannot
    * handle multiple keyboards).
    */
   virtual int GetNumKeyboards() const = 0;
-  
+
   /*
-   * Returns the number of attached mice (or 0 if the system cannot handle mice at all or ANY_MOUSE if the system cannot handle 
+   * Returns the number of attached mice (or 0 if the system cannot handle mice at all or ANY_MOUSE if the system cannot handle
    * multiple mice).
    */
   virtual int GetNumMice() const = 0;
-  
+
   /*
-   * Returns number of attached joysticks (or 0 if the system cannot handle joysticks at all or ANY_JOYSTICK if the system cannot 
+   * Returns number of attached joysticks (or 0 if the system cannot handle joysticks at all or ANY_JOYSTICK if the system cannot
    * handle multiple joysticks).
    */
   virtual int GetNumJoysticks() const = 0;
@@ -820,7 +839,7 @@ public:
    * If no settings are found and useDefault is false, NULL is returned.  If useDefault is true then default settings are returned.
    */
   JoySettings *GetJoySettings(int joyNum, bool useDefault);
-  
+
   /*
    * Returns the input source for the given mapping, or NULL if mapping is not valid.
    */
@@ -833,7 +852,7 @@ public:
    * readFlags specifies which types of inputs (keyboards, mice, joysticks) are to be read and whether to merge the inputs to a common
    * mapping, eg return MOUSE_XAXIS rather than MOUSE3_XAXIS.
    * If fullAxisOnly is true, then only mappings representing a full axis are returned, eg JOY1_XAXIS is allowed but not JOY1_XAXIS_POS.
-   */ 
+   */
   bool ReadMapping(char *buffer, unsigned bufSize, bool fullAxisOnly = false, unsigned readFlags = READ_ALL, const char *escapeMapping = "KEY_ESCAPE");
 
   /*
@@ -871,7 +890,7 @@ public:
     CInputSystem *m_system; // Parent input system
     int m_kbdNum;           // Keyboard number
     int m_keyIndex;         // Key index
-    int m_incr;             // Key increment for analog values 
+    int m_incr;             // Key increment for analog values
     int m_decr;             // Key decrement for analog values
     int m_val;              // Current analog key value
     static constexpr int m_maxVal = 10000; // Maximum analog key value
@@ -886,7 +905,7 @@ public:
 
   /*
    * Input source for the X- or Y-axis of a mouse.
-   */ 
+   */
   class CMseAxisInputSource : public CInputSource
   {
   private:
@@ -916,11 +935,15 @@ public:
   {
   private:
     CInputSystem *m_system; // Parent input system
-    int m_mseNum;           // Mouse number 
+    int m_mseNum;           // Mouse number
     int m_butNum;           // Button number
+    int m_incr;             // Increment for analog values
+    int m_decr;             // Decrement for analog values
+    int m_val;              // Current analog value
+    static constexpr int m_maxVal = 10000; // Maximum analog value
 
   public:
-    CMseButInputSource(CInputSystem *system, int mseNum, int butNum);
+    CMseButInputSource(CInputSystem *system, int mseNum, int butNum, unsigned sensitivity, unsigned decaySpeed);
 
     bool GetValueAsSwitch(bool &val) const;
 
@@ -929,7 +952,7 @@ public:
 
   /*
    * Input source for the axis of a joystick.
-   */ 
+   */
   class CJoyAxisInputSource : public CInputSource
   {
   private:
@@ -972,9 +995,13 @@ public:
     int m_joyNum;           // Joystick number
     int m_povNum;           // POV hat number
     int m_povDir;           // POV hat direction (POV_UP, POV_LEFT, POV_RIGHT, POV_DOWN)
+    int m_incr;             // Increment for analog values
+    int m_decr;             // Decrement for analog values
+    int m_val;              // Current analog value
+    static constexpr int m_maxVal = 10000; // Maximum analog value
 
   public:
-    CJoyPOVInputSource(CInputSystem *system, int joyNum, int povNum, int povDir);
+    CJoyPOVInputSource(CInputSystem *system, int joyNum, int povNum, int povDir, unsigned sensitivity, unsigned decaySpeed);
 
     bool GetValueAsSwitch(bool &val) const;
 
@@ -990,9 +1017,13 @@ public:
     CInputSystem *m_system; // Parent input system
     int m_joyNum;           // Joystick number
     int m_butNum;           // Button number
+    int m_incr;             // Increment for analog values
+    int m_decr;             // Decrement for analog values
+    int m_val;              // Current analog value
+    static constexpr int m_maxVal = 10000; // Maximum analog value
 
   public:
-    CJoyButInputSource(CInputSystem *system, int joyNum, int butNum);
+    CJoyButInputSource(CInputSystem *system, int joyNum, int butNum, unsigned sensivity, unsigned decaySpeed);
 
     bool GetValueAsSwitch(bool &val) const;
 


### PR DESCRIPTION
Introduced InputDigitalSensitivity and InputDigitalDecaySpeed, which are used to increment and decrement analog input values when they are controlled by a digital input (such as a button or key). Previously, InputKeySensitivity and InputKeyDecaySpeed were only available for keyboard keys. These settings remain and, when present, will take precedence over the new common settings but only for keyboard keys. Every other device -- joypad and mouse buttons -- will use the new settings.

Unlike the keyboard settings, these are common and cannot be specified per device. That is, it is possible to specify e.g. InputKeySensitivity for all keyboards or InputKey2Sensitivitiy only for keyboard 2, but there is no analogous behavior for InputDigitalSensitivity. It applies to all devices. It seems useless to have to specify this per-device.