### PR TITLE
Splits the games list and settings, add start up screen selection 

### DIFF
--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1524,6 +1524,7 @@ Util::Config::Node DefaultConfig()
   config.Set("ForceFeedback", false, "ForceFeedback");
   
   // Platform-specific/UI
+  config.Set("StartupScreen", std::string("Games"), "Interface", std::string(""), std::string(""), { std::string("Games"), std::string("Settings") });
   config.Set("New3DEngine", true, "Video");
   config.Set("QuadRendering", false, "Video");
   config.Set("XResolution", 496, "Video");


### PR DESCRIPTION

Splits the games list and settings, also introduces a new option in a new Interface settings tab to select the start up screen (Games List or Settings for now)