### PR TITLE
Add network output compatible with MAME.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build Supermodel
         run: |
-          make -f Makefiles/${{ matrix.makefile }} release NET_BOARD=1 OPT="${OPT_INPUT:-"-O3"}" GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} SILENT=
+          make -f Makefiles/${{ matrix.makefile }} release OPT="${OPT_INPUT:-"-O3"}" GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} SILENT=
           
       - name: Validate build
         run: |
@@ -78,7 +78,7 @@ jobs:
           
       - name: Create package
         run: |
-          make -f Makefiles/${{ matrix.makefile }} pkg NET_BOARD=1 GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} SILENT=
+          make -f Makefiles/${{ matrix.makefile }} pkg GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} SILENT=
           
       - name: Find and upload package
         run: |

--- a/Docs/README.txt
+++ b/Docs/README.txt
@@ -1531,6 +1531,52 @@ All settings are case sensitive.
 
     ----------------
 
+    Name:           Outputs
+
+    Argument:       String.
+
+    Description:    Manages MAME Hooker compatible outputs.
+                    Valid options are:
+                      - none    - default, disables outputs.
+                      - win     - Use Windows messages (only on Windows).
+                      - net     - Use network messages.
+
+                    See OutputsWithLF, OutputsTCPPort and
+                    OutputsUDPBroadcastPort settings when using 'net' option.
+                    Can only be set in the 'Global' section.
+
+    ----------------
+
+    Name:           OutputsWithLF
+
+    Argument:       Boolean value (true or false).
+
+    Description:    When using 'net' option for 'Outputs', this setting determines whether
+                    messages are terminated with a line feed character.  The
+                    default is false. Can only be set in 'Global' section.
+
+    ----------------
+
+    Name:           OutputsTCPPort
+
+    Argument:       Integer value.
+
+    Description:    When using 'net' option for 'Outputs', this setting determines the
+                    TCP port to use for network messages. Can only be set in 'Global'
+                    section.
+
+    ----------------
+
+    Name:           OutputsUDPBroadcastPort
+
+    Argument:       Integer value.
+
+    Description:    When using 'net' option for 'Outputs', this setting determines the
+                    UDP broadcast port to use for network messages. Can only be set
+                    in 'Global' section.
+
+    ----------------
+
     Names:          InputStart1
                     InputStart2
                     InputCoin1

--- a/Makefiles/Makefile.OSX
+++ b/Makefiles/Makefile.OSX
@@ -64,10 +64,7 @@ LD = clang
 #
 
 SDL_CFLAGS =
-SDL_LIBS = -framework SDL2 -framework OpenGL -framework GLUT -framework Cocoa
-ifeq ($(strip $(NET_BOARD)),1)
-	SDL_LIBS += -framework SDL2_net
-endif
+SDL_LIBS = -framework SDL2 -framework SDL2_net -framework OpenGL -framework GLUT -framework Cocoa
 
 #
 # macOS-specific

--- a/Makefiles/Makefile.UNIX
+++ b/Makefiles/Makefile.UNIX
@@ -64,9 +64,7 @@ LD = gcc
 
 SDL2_CFLAGS = `sdl2-config --cflags`
 SDL2_LIBS = `sdl2-config --libs`
-ifeq ($(strip $(NET_BOARD)),1)
-	SDL2_LIBS += -lSDL2_net
-endif
+SDL2_LIBS += -lSDL2_net
 
 #
 #	UNIX-specific

--- a/Makefiles/Makefile.Win32
+++ b/Makefiles/Makefile.Win32
@@ -95,9 +95,7 @@ else
 	SDL2_LIBS = $(shell sdl2-config --static-libs | sed 's/-mwindows//g')
 	SDL2_CFLAGS = $(shell sdl2-config --cflags)
 endif
-ifeq ($(strip $(NET_BOARD)),1)
-	SDL2_LIBS += -lSDL2_net -liphlpapi
-endif
+SDL2_LIBS += -lSDL2_net -liphlpapi
 
 #
 # MinGW/Windows-specific

--- a/Makefiles/Options.inc
+++ b/Makefiles/Options.inc
@@ -52,14 +52,6 @@ ifneq ($(filter $(strip $(EXTRA_DEBUG)),0 1),$(strip $(EXTRA_DEBUG)))
 endif
 
 #
-# Enable support for Model3 Net Board emulation
-#
-NET_BOARD =
-ifneq ($(filter $(strip $(NET_BOARD)),0 1),$(strip $(NET_BOARD)))
-	override NET_BOARD =
-endif
-
-#
 # Include console-based debugger in emulator ('yes' or 'no')
 #
 ENABLE_DEBUGGER =

--- a/Makefiles/Rules.inc
+++ b/Makefiles/Rules.inc
@@ -176,6 +176,7 @@ SRC_FILES = \
 	Src/Pkgs/imgui/imgui_tables.cpp \
 	Src/Pkgs/imgui/imgui_widgets.cpp \
 	Src/ROMSet.cpp \
+	Src/OSD/SDL/NetOutputs.cpp \
 	$(PLATFORM_SRC_FILES)
 
 ifeq ($(strip $(NET_BOARD)),1)

--- a/Makefiles/Rules.inc
+++ b/Makefiles/Rules.inc
@@ -52,11 +52,6 @@ ifeq ($(strip $(EXTRA_DEBUG)),1)
 	SUPERMODEL_BUILD_FLAGS += -DDEBUG
 endif
 
-# If Net Board support is enabled, need to define NET_BOARD
-ifeq ($(strip $(NET_BOARD)),1)
-	SUPERMODEL_BUILD_FLAGS += -DNET_BOARD
-endif
-
 # If built-in debugger enabled, need to define SUPERMODEL_DEBUGGER
 ifeq ($(strip $(ENABLE_DEBUGGER)),1)
 	SUPERMODEL_BUILD_FLAGS += -DSUPERMODEL_DEBUGGER
@@ -177,15 +172,11 @@ SRC_FILES = \
 	Src/Pkgs/imgui/imgui_widgets.cpp \
 	Src/ROMSet.cpp \
 	Src/OSD/SDL/NetOutputs.cpp \
+	Src/Network/TCPReceive.cpp \
+	Src/Network/TCPSend.cpp \
+	Src/Network/NetBoard.cpp \
+	Src/Network/SimNetBoard.cpp \
 	$(PLATFORM_SRC_FILES)
-
-ifeq ($(strip $(NET_BOARD)),1)
-	SRC_FILES += \
-		Src/Network/TCPReceive.cpp \
-		Src/Network/TCPSend.cpp \
-		Src/Network/NetBoard.cpp \
-		Src/Network/SimNetBoard.cpp
-endif
 
 ifeq ($(strip $(ENABLE_DEBUGGER)),1)
 	SRC_FILES += \

--- a/README.md
+++ b/README.md
@@ -50,16 +50,10 @@ pacman -S mingw64/mingw-w64-x86_64-SDL2_net
 
 At this point, you can continue using either the MSYS2 shell or Windows Command Prompt but ensure that both ```gcc``` and ```mingw32-make``` are in your path. In MSYS2, the location of these binaries will be ```/mingw64/bin``` and for Command Prompt, assuming MSYS2 was installed in the default location, add ```C:\msys64\mingw64\bin``` to your Windows ```PATH``` variable.
 
-To build Supermodel without network support, use:
+To build Supermodel use (Network support built in by default now, no need to specify anymore):
 
 ```
 mingw32-make -f Makefiles/Makefile.Win32
-```
-
-For network support:
-
-```
-mingw32-make -f Makefiles/Makefile.Win32 NET_BOARD=1
 ```
 
 ### Linux
@@ -76,12 +70,6 @@ And then build Supermodel:
 
 ```
 make -f Makefiles/Makefile.UNIX
-```
-
-For network support:
-
-```
-make -f Makefiles/Makefile.UNIX NET_BOARD=1
 ```
 
 ### macOS
@@ -104,12 +92,6 @@ And then build Supermodel:
 
 ```
 make -f Makefiles/Makefile.OSX
-```
-
-For network support:
-
-```
-make -f Makefiles/Makefile.OSX NET_BOARD=1
 ```
 
 ### Note: running on macOS

--- a/Scripts/netoutput_tester.py
+++ b/Scripts/netoutput_tester.py
@@ -1,0 +1,479 @@
+# Supermodel
+# A Sega Model 3 Arcade Emulator.
+# Copyright 2003-2026 The Supermodel Team
+#
+# This file is part of Supermodel.
+#
+# Supermodel is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option)
+# any later version.
+#
+# Supermodel is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with Supermodel.  If not, see <http://www.gnu.org/licenses/>.
+
+###############################################################################
+# Network output tester for Supermodel - receives messages via UDP and TCP.
+#
+# This script is designed to test the network output functionality of
+# Supermodel by listening for messages sent by the emulator and processing
+# them.
+# It can be used to verify that Supermodel is sending the correct messages in
+# response to various events (e.g., starting/stopping the emulator, pausing,
+# etc.).
+#
+# Usage:
+#  python netoutput_tester.py [--udp-port UDP_PORT] [--tcp-host TCP_HOST]
+#                           [--tcp-port TCP_PORT] [--max-runtime MAX_RUNTIME]
+#
+#  --tcp-host TCP_HOST       TCP host to connect to (default: localhost)
+#  --tcp-port TCP_PORT       TCP port to connect to (default: 8000)
+#  --udp-port UDP_PORT       UDP port to listen on (default: 8001)
+#  --max-runtime MAX_RUNTIME Maximum runtime in seconds (default: run forever)
+#
+# The script will print received messages to the console and can be stopped
+# with Ctrl+C.
+###############################################################################
+
+
+import argparse
+import logging
+import signal
+import socket
+import sys
+import threading
+import time
+from collections.abc import Callable
+from types import FrameType
+
+# Configure logging.
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+class MessageProcessor:
+    """Processes incoming messages from UDP and TCP connections.
+
+    Handles both static keys (with dedicated handler functions) and dynamic keys
+    (with a generic handler function).
+    """
+
+    def __init__(self) -> None:
+        """Initialize the message processor with static key handlers."""
+        self._static_handlers: dict[str, Callable[[str | None, str], None]] = {
+            "mame_start": self._handle_mame_start,
+            "pause": self._handle_pause,
+            "mame_stop": self._handle_mame_stop,
+            "tcp": self._handle_tcp,
+        }
+
+    def parse_message(self, message: str) -> tuple[str, str | None]:
+        """Parse a message into key and optional value.
+
+        Args:
+            message (str): Raw message string to parse.
+
+        Returns:
+            tuple[str, str | None]: A tuple containing the key and optional value.
+                Value is None if not present.
+        """
+        # Strip blanks from the line.
+        message = message.strip()
+
+        key: str
+        value: str | None
+        if "=" in message:
+            # Split by '=' and strip blanks from both parts.
+            parts: list[str] = message.split("=", 1)
+            key = parts[0].strip()
+            value = parts[1].strip() if len(parts) > 1 else None
+        else:
+            # No value, just a key.
+            key = message
+            value = None
+
+        return key, value
+
+    def process_message(self, message: str, source: str) -> None:
+        """Process a received message by delegating to appropriate handler.
+
+        Args:
+            message (str): The message string to process.
+            source (str): The source of the message (e.g., "UDP" or "TCP").
+        """
+        if not message:
+            return
+
+        key: str
+        value: str | None
+        key, value = self.parse_message(message)
+
+        if not key:
+            return
+
+        # Check if it's a static key.
+        if key in self._static_handlers:
+            LOGGER.debug("Processing static key from %s: %s = %s", source, key, value)
+            self._static_handlers[key](value, source)
+        else:
+            # Handle as dynamic key.
+            LOGGER.debug("Processing dynamic key from %s: %s = %s", source, key, value)
+            self._handle_dynamic_key(key, value, source)
+
+    def _handle_mame_start(self, value: str | None, source: str) -> None:
+        """Handle the mame_start command.
+
+        Args:
+            value (str | None): Optional value associated with the command.
+            source (str): The source of the message (e.g., "UDP" or "TCP").
+        """
+        LOGGER.info("MAME START command received from %s with value: %s", source, value)
+
+    def _handle_pause(self, value: str | None, source: str) -> None:
+        """Handle the pause command.
+
+        Args:
+            value (str | None): Optional value associated with the command.
+            source (str): The source of the message (e.g., "UDP" or "TCP").
+        """
+        LOGGER.info("PAUSE command received from %s with value: %s", source, value)
+
+    def _handle_mame_stop(self, value: str | None, source: str) -> None:
+        """Handle the mame_stop command.
+
+        Args:
+            value (str | None): Optional value associated with the command.
+            source (str): The source of the message (e.g., "UDP" or "TCP").
+        """
+        LOGGER.info("MAME STOP command received from %s with value: %s", source, value)
+
+    def _handle_tcp(self, value: str | None, source: str) -> None:
+        """Handle the tcp command.
+
+        Args:
+            value (str | None): Optional value associated with the command.
+            source (str): The source of the message (e.g., "UDP" or "TCP").
+        """
+        LOGGER.info("TCP command received from %s with value: %s", source, value)
+
+    def _handle_dynamic_key(self, key: str, value: str | None, source: str) -> None:
+        """Handle dynamic keys that are not in the static handler list.
+
+        Args:
+            key (str): The dynamic key name.
+            value (str | None): Optional value associated with the key.
+            source (str): The source of the message (e.g., "UDP" or "TCP").
+        """
+        LOGGER.info("Dynamic key '%s' received from %s with value: %s", key, source, value)
+
+
+class UDPReceiver:
+    """Receives and processes UDP messages on a configurable port."""
+
+    def __init__(self, processor: MessageProcessor, port: int = 8001, buffer_size: int = 4096) -> None:
+        """Initialize the UDP receiver.
+
+        Args:
+            processor (MessageProcessor): The message processor to handle received messages.
+            port (int): The port to listen on (default: 8001).
+            buffer_size (int): The buffer size for receiving data (default: 4096).
+        """
+        self._processor: MessageProcessor = processor
+        self._port: int = port
+        self._buffer_size: int = buffer_size
+        self._running: bool = False
+        self._thread: threading.Thread | None = None
+        self._socket: socket.socket | None = None
+
+    def start(self) -> None:
+        """Start the UDP receiver in a separate thread."""
+        if self._running:
+            LOGGER.warning("UDP receiver is already running.")
+            return
+
+        self._running = True
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        LOGGER.info("UDP receiver started on port %d.", self._port)
+
+    def stop(self) -> None:
+        """Stop the UDP receiver."""
+        if not self._running:
+            return
+
+        self._running = False
+        if self._socket:
+            self._socket.close()
+        if self._thread:
+            self._thread.join(timeout=5.0)
+        LOGGER.info("UDP receiver stopped.")
+
+    def _run(self) -> None:  # pylint: disable=too-many-branches  # noqa: PLR0912
+        """Main loop for the UDP receiver thread."""
+        try:
+            # Create UDP socket.
+            self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            self._socket.bind(("", self._port))
+            LOGGER.info("UDP socket bound to port %d.", self._port)
+            # Set a timeout to allow periodic checks for shutdown.
+            self._socket.settimeout(0.1)
+
+            # Buffer for incomplete messages.
+            buffer: str = ""
+
+            while self._running:
+                try:
+                    # Receive data.
+                    data: bytes
+                    addr: tuple[str, int]
+                    data, addr = self._socket.recvfrom(self._buffer_size)
+                    if not data:
+                        continue
+
+                    # Decode the data.
+                    text: str = data.decode("utf-8", errors="ignore")
+                    buffer += text
+
+                    # Process complete lines.
+                    while "\n" in buffer or "\r" in buffer:
+                        # Split on both \r\n and \n.
+                        line: str
+                        if "\r\n" in buffer:
+                            line, buffer = buffer.split("\r\n", 1)
+                        elif "\n" in buffer:
+                            line, buffer = buffer.split("\n", 1)
+                        elif "\r" in buffer:
+                            line, buffer = buffer.split("\r", 1)
+                        else:
+                            break
+
+                        # Process the line.
+                        if line:
+                            LOGGER.debug("UDP received from %s: %s.", addr, line)
+                            self._processor.process_message(line, source="UDP")
+
+                except TimeoutError:
+                    continue
+                except OSError as e:
+                    if self._running:
+                        LOGGER.error("UDP socket error: %s", e)
+                        break
+
+        except Exception as e:  # pylint: disable=broad-except
+            LOGGER.error("UDP receiver error: %s", e)
+        finally:
+            if self._socket:
+                self._socket.close()
+
+
+class TCPConnector:  # pylint: disable=too-many-instance-attributes
+    """Connects to a TCP server and processes incoming messages."""
+
+    def __init__(  # pylint: disable=too-many-positional-arguments, too-many-arguments
+        self,
+        processor: MessageProcessor,
+        host: str = "localhost",
+        port: int = 8000,
+        retry_interval: float = 0.1,
+        buffer_size: int = 4096,
+    ) -> None:
+        """Initialize the TCP connector.
+
+        Args:
+            processor (MessageProcessor): The message processor to handle received messages.
+            host (str): The hostname to connect to (default: "localhost").
+            port (int): The port to connect to (default: 8000).
+            retry_interval (float): The interval in seconds between connection attempts
+                (default: 0.1).
+            buffer_size (int): The buffer size for receiving data (default: 4096).
+        """
+        self._processor: MessageProcessor = processor
+        self._host: str = host
+        self._port: int = port
+        self._retry_interval: float = retry_interval
+        self._buffer_size: int = buffer_size
+        self._running: bool = False
+        self._thread: threading.Thread | None = None
+        self._socket: socket.socket | None = None
+
+    def start(self) -> None:
+        """Start the TCP connector in a separate thread."""
+        if self._running:
+            LOGGER.warning("TCP connector is already running.")
+            return
+
+        self._running = True
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        LOGGER.info("TCP connector started, will connect to %s:%d.", self._host, self._port)
+
+    def stop(self) -> None:
+        """Stop the TCP connector."""
+        if not self._running:
+            return
+
+        self._running = False
+        if self._socket:
+            self._socket.close()
+        if self._thread:
+            self._thread.join(timeout=5.0)
+        LOGGER.info("TCP connector stopped.")
+
+    def _run(self) -> None:  # pylint: disable=too-many-branches  # noqa: PLR0912,PLR0915,C901
+        """Main loop for the TCP connector thread."""
+        LOGGER.info("Attempting to connect to %s:%d.", self._host, self._port)
+        while self._running:  # pylint: disable=too-many-nested-blocks
+            try:
+                # Try to connect.
+                self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self._socket.settimeout(5.0)
+                self._socket.connect((self._host, self._port))
+                LOGGER.info("Connected to %s:%d.", self._host, self._port)
+
+                # Buffer for incomplete messages.
+                buffer: str = ""
+
+                # Receive loop.
+                while self._running:
+                    try:
+                        data: bytes = self._socket.recv(self._buffer_size)
+                        if not data:
+                            LOGGER.info("TCP connection closed by server.")
+                            break
+
+                        # Decode the data.
+                        text: str = data.decode("utf-8", errors="ignore")
+                        buffer += text
+
+                        # Process complete lines.
+                        while "\n" in buffer or "\r" in buffer:
+                            # Split on both \r\n and \n.
+                            line: str
+                            for delimiter in ("\r\n", "\n", "\r"):
+                                if delimiter in buffer:
+                                    line, buffer = buffer.split(delimiter, 1)
+                                    break
+                            else:
+                                break
+
+                            # Process the line.
+                            if line:
+                                LOGGER.debug("TCP received: %s.", line)
+                                self._processor.process_message(line, source="TCP")
+
+                    except TimeoutError:
+                        continue
+                    except OSError as e:
+                        if self._running:
+                            LOGGER.error("TCP socket error: %s", e)
+                            break
+
+            except (TimeoutError, ConnectionRefusedError):
+                if self._running:
+                    time.sleep(self._retry_interval)
+            except Exception as e:  # pylint: disable=broad-except
+                if self._running:
+                    LOGGER.error("TCP connection error: %s", e)
+                    LOGGER.info("Retrying in %s seconds...", self._retry_interval)
+                    time.sleep(self._retry_interval)
+            finally:
+                if self._socket:
+                    self._socket.close()
+                    self._socket = None
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        argparse.Namespace: Parsed command-line arguments.
+    """
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        description="Network output tester for Supermodel - receives messages via UDP and TCP."
+    )
+
+    parser.add_argument("--udp-port", type=int, default=8001, help="UDP port to listen on (default: 8001)")
+
+    parser.add_argument("--tcp-host", type=str, default="localhost", help="TCP host to connect to (default: localhost)")
+
+    parser.add_argument("--tcp-port", type=int, default=8000, help="TCP port to connect to (default: 8000)")
+
+    parser.add_argument(
+        "--max-runtime", type=int, default=None, help="Maximum runtime in seconds (default: run forever)"
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Main entry point for the network output tester."""
+    print("  ####                                                      ###           ###")
+    print(" ##  ##                                                      ##            ##")
+    print(" ###     ##  ##  ## ###   ####   ## ###  ##  ##   ####       ##   ####     ##")
+    print("  ###    ##  ##   ##  ## ##  ##   ### ## ####### ##  ##   #####  ##  ##    ##")
+    print("    ###  ##  ##   ##  ## ######   ##  ## ####### ##  ##  ##  ##  ######    ##")
+    print(" ##  ##  ##  ##   #####  ##       ##     ## # ## ##  ##  ##  ##  ##        ##")
+    print("  ####    ### ##  ##      ####   ####    ##   ##  ####    ### ##  ####    ####")
+    print("                 ####")
+    print("")
+    print("Network Output Tester v1.0.0")
+    print()
+
+    # Parse command-line arguments.
+    args: argparse.Namespace = parse_arguments()
+
+    # Create message processor.
+    processor: MessageProcessor = MessageProcessor()
+
+    # Create and start UDP receiver.
+    udp_receiver: UDPReceiver = UDPReceiver(processor, port=args.udp_port)
+    udp_receiver.start()
+
+    # Create and start TCP connector.
+    tcp_connector: TCPConnector = TCPConnector(processor, host=args.tcp_host, port=args.tcp_port)
+    tcp_connector.start()
+
+    # Setup signal handler for immediate exit on Ctrl-C.
+    def signal_handler(sig: int, frame: FrameType | None) -> None:
+        """Handle SIGINT for immediate shutdown.
+
+        Args:
+            sig (int): The signal number.
+            frame (FrameType | None): The current stack frame.
+        """
+        _ = sig, frame  # Unused parameters.
+        LOGGER.info("\nShutting down...")
+        udp_receiver.stop()
+        tcp_connector.stop()
+        LOGGER.info("Shutdown complete.")
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, signal_handler)
+
+    if args.max_runtime:
+        LOGGER.info("Network output tester is running for %d seconds. Press Ctrl+C to stop.", args.max_runtime)
+    else:
+        LOGGER.info("Network output tester is running. Press Ctrl+C to stop.")
+
+    # Keep the main thread alive.
+    start_time: float = time.time()
+    while True:
+        # Check if maximum runtime has been exceeded.
+        if args.max_runtime:
+            elapsed: float = time.time() - start_time
+            if elapsed >= args.max_runtime:
+                LOGGER.info("Maximum runtime of %d seconds reached. Shutting down...", args.max_runtime)
+                udp_receiver.stop()
+                tcp_connector.stop()
+                break
+
+        time.sleep(0.1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/supermodel_build_bot.py
+++ b/Scripts/supermodel_build_bot.py
@@ -240,7 +240,7 @@ def update_git_snapshot(working_dir, username, password, test_run, make):
       if result.returncode != 0:
         raise BuildError("Failed to obtain version")
       version = result.stdout.decode().strip()
-      result = bash.execute(working_dir=repo_dir, command=make + " -f Makefiles/Makefile.Win32 release NET_BOARD=1", print_output=False)
+      result = bash.execute(working_dir=repo_dir, command=make + " -f Makefiles/Makefile.Win32 release", print_output=False)
       if result.returncode != 0:
         raise BuildError("Build failed")
 

--- a/Src/Debugger/SupermodelDebugger.cpp
+++ b/Src/Debugger/SupermodelDebugger.cpp
@@ -22,7 +22,6 @@
 /*
  * SupermodelDebugger.cpp
  */
-
 #ifdef SUPERMODEL_DEBUGGER
 
 #include "SupermodelDebugger.h"
@@ -32,9 +31,7 @@
 #include "ConsoleDebugger.h"
 #include "CPUDebug.h"
 #include "Label.h"
-#ifdef NET_BOARD
 #include "Network/NetBoard.h"
-#endif // NET_BOARD
 #include "CPU/Musashi68KDebug.h"
 #include "CPU/PPCDebug.h"
 #include "CPU/Z80Debug.h"
@@ -78,13 +75,17 @@ namespace Debugger
 		cpu->AddRegion(0x90000000, 0x9000000B, false, false, "Real3D VROM Texture Port");
 		cpu->AddRegion(0x94000000, 0x940FFFFF, false, false, "Real3D Texture FIFO");
 		cpu->AddRegion(0x98000000, 0x980FFFFF, false, false, "Real3D Polygon RAM");
-#ifndef NET_BOARD
-		cpu->AddRegion(0xC0000000, 0xC00000FF, false, false, "SCSI (Step 1.x)");
-#endif
-#ifdef NET_BOARD
-		cpu->AddRegion(0xC0000000, 0xC000FFFF, false, false, "Netboard Shared RAM (Step 1.5+)");
-		cpu->AddRegion(0xC0020000, 0xC002FFFF, false, false, "Netboard Program RAM (Step 1.5+)");
-#endif
+		if (!model3->GetGame().netboard_present)
+		{
+			// Netboard not present, SCSI is at 0xC0000000.
+			cpu->AddRegion(0xC0000000, 0xC00000FF, false, false, "SCSI (Step 1.x)");
+		}
+		else
+		{
+			// Netboard present, 0xC0000000 is used for netboard RAM.
+			cpu->AddRegion(0xC0000000, 0xC000FFFF, false, false, "Netboard Shared RAM (Step 1.5+)");
+			cpu->AddRegion(0xC0020000, 0xC002FFFF, false, false, "Netboard Program RAM (Step 1.5+)");
+		}
 		cpu->AddRegion(0xC1000000, 0xC10000FF, false, false, "SCSI (Step 1.x) (Lost World expects it here)");
 		cpu->AddRegion(0xC2000000, 0xC20000FF, false, false, "Real3D DMA (Step 2.x)");
 		cpu->AddRegion(0xF0040000, 0xF004003F, false, false, "Input (Controls) Registers");
@@ -312,7 +313,6 @@ namespace Debugger
 		return cpu;
 	}
 
-#ifdef NET_BOARD
 	CCPUDebug *CSupermodelDebugger::CreateNetBoardCPUDebug(::CModel3 * model3)
 	{
 		CNetBoard *netBrd = dynamic_cast<CNetBoard*>(model3->GetNetBoard());
@@ -336,7 +336,6 @@ namespace Debugger
 
 		return cpu;
 	}
-#endif
 
 	CSupermodelDebugger::CSupermodelDebugger(::CModel3 *model3, ::CInputs *inputs, std::shared_ptr<CLogger> logger) :
 		CConsoleDebugger(), m_model3(model3), m_inputs(inputs), m_logger(logger),
@@ -365,11 +364,9 @@ namespace Debugger
 		cpu = CreateDriveBoardCPUDebug(m_model3);
 		if (cpu) AddCPU(cpu);
 
-#ifdef NET_BOARD
 		// Add net board CPU (if attached)
 		cpu = CreateNetBoardCPUDebug(m_model3);
 		if (cpu) AddCPU(cpu);
-#endif
 
 	}
 

--- a/Src/Debugger/SupermodelDebugger.h
+++ b/Src/Debugger/SupermodelDebugger.h
@@ -79,9 +79,8 @@ namespace Debugger
 		static CCPUDebug *CreateDSBCPUDebug(::CModel3 *model3);
 
 		static CCPUDebug *CreateDriveBoardCPUDebug(::CModel3 *model3);
-#ifdef NET_BOARD
+
 		static CCPUDebug *CreateNetBoardCPUDebug(::CModel3 *model3);
-#endif
 
 		CSupermodelDebugger(::CModel3 *model3, ::CInputs *inputs, std::shared_ptr<CLogger> logger);
 

--- a/Src/Model3/Model3.cpp
+++ b/Src/Model3/Model3.cpp
@@ -226,10 +226,8 @@
 #include "DriveBoard/WheelBoard.h"
 #include "Game.h"
 #include "ROMSet.h"
-#ifdef NET_BOARD
 #include "Network/NetBoard.h"
 #include "Network/SimNetBoard.h"
-#endif // NET_BOARD
 #include "OSD/Audio.h"
 #include "OSD/Video.h"
 #include "Util/Format.h"
@@ -1017,50 +1015,39 @@ UINT8 CModel3::Read8(UINT32 addr)
 
   // 53C810 SCSI
   case 0xC0:  // only on Step 1.x
-#ifndef NET_BOARD
-    if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0)
+    if (m_runNetBoard)
     {
-      //printf("Model3 : Read8 %x\n", addr);
-      break;
-    }
-#endif
-#ifdef NET_BOARD
-  if (m_runNetBoard)
-  {
-    switch ((addr & 0x3ffff) >> 16)
-    {
-    case 0:
-      return NetBoard->ReadCommRAM8((addr & 0xFFFF) ^ 2);
-
-    case 1: // ioreg 32bits access in 16bits environment
-      if (addr > 0xc00101ff)
+      switch ((addr & 0x3ffff) >> 16)
       {
+      case 0:
+        return NetBoard->ReadCommRAM8((addr & 0xFFFF) ^ 2);
+
+      case 1: // ioreg 32bits access in 16bits environment
+        if (addr > 0xc00101ff)
+        {
+          printf("R8 ATTENTION OUT OF RANGE\n");
+          SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Info", "Out of Range", NULL);
+        }
+        return (UINT8)NetBoard->ReadIORegister((addr & 0x1FF) / 2);
+
+      case 2:
+      case 3:
+        return netRAM[((addr & 0x1FFFF) / 2)];
+
+      default:
         printf("R8 ATTENTION OUT OF RANGE\n");
         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Info", "Out of Range", NULL);
+        break;
       }
-      return (UINT8)NetBoard->ReadIORegister((addr & 0x1FF) / 2);
-
-    case 2:
-    case 3:
-      return netRAM[((addr & 0x1FFFF) / 2)];
-
-    default:
-      printf("R8 ATTENTION OUT OF RANGE\n");
-      SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Info", "Out of Range", NULL);
-      break;
     }
-  }
   else if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0) break;
-#endif
   case 0xF9:
   case 0xC1:
     return SCSI.ReadRegister(addr&0xFF);
 
   // Unknown
   default:
-#ifdef NET_BOARD
     printf("CMODEL3 : unknown R8 : %x\n", addr >> 24);
-#endif
     break;
   }
 
@@ -1150,7 +1137,6 @@ UINT16 CModel3::Read16(UINT32 addr)
     }
     break;
 
-#ifdef NET_BOARD
   case 0xc0: // spikeout calls this
   // interesting : poking @4 master to same value as slave (0x100) or simply !=0 -> connected and go in game, but freeze (prints comm error) as soon as players appear after the gate
   // sort of sync ack ? who writes this 16b value ?
@@ -1167,13 +1153,10 @@ UINT16 CModel3::Read16(UINT32 addr)
     }
   }
   break;
-#endif
   // Unknown
   default:
-#ifdef NET_BOARD
     printf("CMODEL3 : unknown R16 : %x (%x)\n", addr, addr >> 24);
     SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Info", "CMODEL3 : Unknown R16", NULL);
-#endif
     break;
   }
 
@@ -1312,11 +1295,6 @@ UINT32 CModel3::Read32(UINT32 addr)
 
   // 53C810 SCSI
   case 0xC0:  // only on Step 1.x
-#ifndef NET_BOARD
-    if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0) // check for Step 1.x
-      break;
-#endif
-#ifdef NET_BOARD
     if (m_runNetBoard)
     {
       UINT32 result;
@@ -1349,7 +1327,6 @@ UINT32 CModel3::Read32(UINT32 addr)
 
     }
     else if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0) break;
-#endif
   case 0xF9:
   case 0xC1:
     data =  (SCSI.ReadRegister((addr+0)&0xFF) << 24);
@@ -1360,9 +1337,7 @@ UINT32 CModel3::Read32(UINT32 addr)
 
   // Unknown
   default:
-#ifdef NET_BOARD
     printf("CMODEL3 : unknown R32 : %x\n", addr >> 24);
-#endif
     break;
   }
 
@@ -1476,11 +1451,6 @@ void CModel3::Write8(UINT32 addr, UINT8 data)
 
   // 53C810 SCSI
   case 0xC0:  // only on Step 1.x
-#ifndef NET_BOARD
-    if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0)
-      goto Unknown8;
-#endif
-#ifdef NET_BOARD
     if (m_runNetBoard)
     {
       //printf("CModel 3 : write8 %x<-%x\n", addr, data);
@@ -1513,7 +1483,6 @@ void CModel3::Write8(UINT32 addr, UINT8 data)
       break;
     }
     else if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0) break;
-#endif
   case 0xF9:
   case 0xC1:
     SCSI.WriteRegister(addr&0xFF,data);
@@ -1522,9 +1491,7 @@ void CModel3::Write8(UINT32 addr, UINT8 data)
   // Unknown:
   default:
   Unknown8:
-#ifdef NET_BOARD
     //printf("CMODEL3 : unknown W8 : %x\n", addr >> 24); // harleyb unknown 0xF1
-#endif
     DebugLog("PC=%08X\twrite8 : %08X=%02X\n", ppc_get_pc(), addr, data);
     break;
   }
@@ -1596,10 +1563,8 @@ void CModel3::Write16(UINT32 addr, UINT16 data)
     PCIBridge.WriteRegister((addr&0xFF)+1,data&0xFF);
     break;
 
-#ifdef NET_BOARD
   case 0xC0: // skichamp only
     //printf("CModel 3 : write16 %x<-%x\n", addr, data);
-
 
     switch ((addr & 0x3ffff) >> 16)
     {
@@ -1613,7 +1578,6 @@ void CModel3::Write16(UINT32 addr, UINT16 data)
     }
 
     break;
-#endif
 
   // Unknown
   default:
@@ -1801,11 +1765,6 @@ void CModel3::Write32(UINT32 addr, UINT32 data)
 
   // 53C810 SCSI
   case 0xC0:  // step 1.x only
-#ifndef NET_BOARD
-    if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0)
-      goto Unknown32;
-#endif
-#ifdef NET_BOARD
     if (m_runNetBoard)
     {
       UINT32 temp;
@@ -1838,7 +1797,6 @@ void CModel3::Write32(UINT32 addr, UINT32 data)
       break;
     }
     else if (m_stepping > 0x15 || SCSI.GetBaseAddress() != 0xC0) break;
-#endif
   case 0xF9:
   case 0xC1:
     SCSI.WriteRegister((addr&0xFF)+0,(data>>24)&0xFF);
@@ -1850,9 +1808,7 @@ void CModel3::Write32(UINT32 addr, UINT32 data)
   // Unknown
   default:
   Unknown32:
-#ifdef NET_BOARD
-      if (m_runNetBoard) printf("CMODEL3 : unknown W32 : %x (%x) data=%d\n", addr,addr >> 24,data);
-#endif
+    if (m_runNetBoard) printf("CMODEL3 : unknown W32 : %x (%x) data=%d\n", addr,addr >> 24,data);
     //printf("PC=%08X\twrite32: %08X=%08X\n", ppc_get_pc(), addr, data);
     DebugLog("PC=%08X\twrite32: %08X=%08X\n", ppc_get_pc(), addr, data);
     break;
@@ -2023,10 +1979,8 @@ void CModel3::RunFrame(void)
     if (m_gpuMultiThreaded)
       SyncGPUs();
 
-#ifdef NET_BOARD
     if (NetBoard->IsRunning() && m_config["SimulateNet"].ValueAs<bool>())
         RunNetBoardFrame();
-#endif
   }
   else
   {
@@ -2037,10 +1991,8 @@ void CModel3::RunFrame(void)
     RunSoundBoardFrame();
     if (DriveBoard->IsAttached())
       RunDriveBoardFrame();
-#ifdef NET_BOARD
     if (NetBoard->IsRunning())
       RunNetBoardFrame();
-#endif
   }
 
   timings.frameTicks = CThread::GetTicks() - start;
@@ -2228,12 +2180,10 @@ void CModel3::RunDriveBoardFrame(void)
   timings.drvTicks = CThread::GetTicks() - start;
 }
 
-#ifdef NET_BOARD
 void CModel3::RunNetBoardFrame(void)
 {
   NetBoard->RunFrame();
 }
-#endif
 
 bool CModel3::StartThreads(void)
 {
@@ -2877,10 +2827,8 @@ void CModel3::Reset(void)
   timings.renderTicks = 0;
   timings.sndTicks = 0;
   timings.drvTicks = 0;
-#ifdef NET_BOARD
   timings.netTicks = 0;
   NetBoard->Reset();
-#endif
   timings.frameTicks = 0;
   timings.frameId = 0;
   
@@ -3094,7 +3042,6 @@ Result CModel3::LoadGame(const Game &game, const ROMSet &rom_set)
   std::cout << std::endl;
 
   m_game = game;
-#ifdef NET_BOARD
   NetBoard->GetGame(m_game);
   if (Result::OKAY != NetBoard->Init(netRAM, netBuffer))
   {
@@ -3102,7 +3049,7 @@ Result CModel3::LoadGame(const Game &game, const ROMSet &rom_set)
   }
 
   m_runNetBoard = m_game.stepping != "1.0" && NetBoard->IsAttached();
-#endif
+
   return Result::OKAY;
 }
 
@@ -3217,12 +3164,10 @@ Result CModel3::Init(void)
   PCIBus.AttachDevice(14,&SCSI);
   PCIBus.AttachDevice(16,this);
 
-#ifdef NET_BOARD
   if (m_config["SimulateNet"].ValueAs<bool>())
       NetBoard = new CSimNetBoard(m_config);
   else
       NetBoard = new CNetBoard(m_config);
-#endif // NET_BOARD
 
   DebugLog("Initialized Model 3 (allocated %1.1f MB)\n", memSizeMB);
 
@@ -3239,12 +3184,10 @@ CDriveBoard *CModel3::GetDriveBoard(void)
   return DriveBoard;
 }
 
-#ifdef NET_BOARD
 INetBoard *CModel3::GetNetBoard(void)
 {
   return NetBoard;
 }
-#endif
 
 CModel3::CModel3(Util::Config::Node &config)
   : m_config(config),
@@ -3279,10 +3222,8 @@ CModel3::CModel3(Util::Config::Node &config)
   DSB = NULL;
   DriveBoard = NULL;
 
-#ifdef NET_BOARD
   NetBoard = NULL;
   m_runNetBoard = false;
-#endif
 
   securityPtr = 0;
 
@@ -3381,13 +3322,11 @@ CModel3::~CModel3(void)
       DriveBoard = NULL;
   }
 
-#ifdef NET_BOARD
   if (NetBoard != NULL)
   {
       delete NetBoard;
       NetBoard = NULL;
   }
-#endif
 
   Inputs = NULL;
   Outputs = NULL;

--- a/Src/Model3/Model3.h
+++ b/Src/Model3/Model3.h
@@ -41,9 +41,7 @@
 #include "TileGen.h"
 #include "DriveBoard/DriveBoard.h"
 #include "CPU/PowerPC/ppc.h"
-#ifdef NET_BOARD
 #include "Network/INetBoard.h"
-#endif // NET_BOARD
 #include "Util/NewConfig.h"
 #include "Graphics/SuperAA.h"
 #include "OSD/Thread.h"
@@ -61,9 +59,7 @@ struct FrameTimings
   UINT32 renderTicks;
   UINT32 sndTicks;
   UINT32 drvTicks;
-#ifdef NET_BOARD
   UINT32 netTicks;
-#endif
   UINT32 frameTicks;
   UINT64 frameId;
 };
@@ -150,7 +146,6 @@ public:
    */
   CDriveBoard *GetDriveBoard(void);
 
-#ifdef NET_BOARD
   /*
   * GetNetBoard(void):
   *
@@ -160,7 +155,6 @@ public:
   *    Pointer to CNetBoard or CSimNetBoard object.
   */
   INetBoard * GetNetBoard(void);
-#endif
 
   /*
    * DumpTimings(void):
@@ -211,9 +205,7 @@ private:
   void SyncGPUs(void);                                // Sync's up GPUs in preparation for rendering - must be called when PPC is not running
   bool RunSoundBoardFrame(void);                      // Runs sound board for a frame
   void RunDriveBoardFrame(void);                      // Runs drive board for a frame
-#ifdef NET_BOARD
   void RunNetBoardFrame(void);                        // Runs net board for a frame
-#endif
 
   bool    StartThreads(void);                         // Starts all threads
   bool    StopThreads(void);                          // Stops all threads
@@ -325,10 +317,8 @@ private:
   CCrypto     m_cryptoDevice; // Encryption device
   CJTAG       m_jtag;         // JTAG interface
   SuperAA     *m_superAA;
-#ifdef NET_BOARD
   INetBoard   *NetBoard;      // Net board
-  bool		m_runNetBoard;
-#endif
+  bool		    m_runNetBoard;
 };
 
 

--- a/Src/Network/NetBoard.cpp
+++ b/Src/Network/NetBoard.cpp
@@ -53,7 +53,6 @@
 // scud canceled network, reset
 // dirtdlvs starts to run, this is at least 1 good news (add skichamp & harley)
 
-// add NET_BOARD for building
 // do not forget -no-threads when launching
 //
 // in supermodel.ini

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -78,6 +78,7 @@
 #include "DirectInputSystem.h"
 #include "WinOutputs.h"
 #endif
+#include "NetOutputs.h"
 
 #include "Supermodel.h"
 #include "Util/Format.h"
@@ -1583,7 +1584,16 @@ Util::Config::Node DefaultConfig()
   config.Set("SDLVibrateMax", 100, "ForceFeedback", 0, 100);
   config.Set("SDLConstForceThreshold", 30, "ForceFeedback", 0, 100);
 #endif
-  config.Set<std::string>("Outputs", "none", "Misc", "", "", { "none","win" });
+
+#ifdef SUPERMODEL_WIN32
+  config.Set<std::string>("Outputs", "none", "Misc", "", "", { "none","win","net" });
+#else
+  config.Set<std::string>("Outputs", "none", "Misc", "", "", { "none","net" });
+#endif
+  config.Set<bool>("OutputsWithLF", false, "Misc");
+  config.Set<unsigned int>("OutputsTCPPort", 8000, "Misc", 1024, 65535);
+  config.Set<unsigned int>("OutputsUDPBroadcastPort", 8001, "Misc", 1024, 65535);
+
   config.Set("DumpMemory", false, "Misc");
   config.Set("DumpTextures", false, "Misc");
 
@@ -2410,13 +2420,23 @@ int main(int argc, char **argv)
     goto Exit;
 
   // Create outputs
-#ifdef SUPERMODEL_WIN32
   {
     std::string outputs = s_runtime_config["Outputs"].ValueAs<std::string>();
     if (outputs == "none")
       Outputs = NULL;
-    else if (outputs == "win")
+    else if (outputs == "net") 
+    {
+        CNetOutputs* netOutputs = new CNetOutputs();
+        if (s_runtime_config["OutputsWithLF"].ValueAs<bool>())
+            netOutputs->SetFrameEnding(std::string("\r\n"));
+        netOutputs->SetTcpPort(s_runtime_config["OutputsTCPPort"].ValueAs<unsigned int>());
+        netOutputs->SetUdpBroadcastPort(s_runtime_config["OutputsUDPBroadcastPort"].ValueAs<unsigned int>());
+        Outputs = (COutputs*)netOutputs;
+#ifdef SUPERMODEL_WIN32
+    } else if (outputs == "win") {
       Outputs = new CWinOutputs();
+#endif // SUPERMODEL_WIN32
+    }
     else
     {
       ErrorLog("Unknown outputs: %s\n", outputs.c_str());
@@ -2424,7 +2444,6 @@ int main(int argc, char **argv)
       goto Exit;
     }
   }
-#endif // SUPERMODEL_WIN32
 
   // Initialize outputs
   if (Outputs != NULL && !Outputs->Initialize())

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1566,15 +1566,6 @@ Util::Config::Node DefaultConfig()
   config.Set("SDLFrictionMax", 100, "ForceFeedback", 0, 100);
   config.Set("SDLVibrateMax", 100, "ForceFeedback", 0, 100);
   config.Set("SDLConstForceThreshold", 30, "ForceFeedback", 0, 100);
-#ifdef NET_BOARD
-
-  // NetBoard
-  config.Set("Network", false, "Network");
-  config.Set("SimulateNet", true, "Network");
-  config.Set("PortIn", unsigned(1970), "Network");
-  config.Set("PortOut", unsigned(1971), "Network");
-  config.Set<std::string>("AddressOut", "127.0.0.1", "Network", "", "");
-#endif
 #else
   config.Set<std::string>("InputSystem", "sdl", "Core", "", "", { "sdl","sdlgamepad" });
   // SDL ForceFeedback
@@ -1584,6 +1575,12 @@ Util::Config::Node DefaultConfig()
   config.Set("SDLVibrateMax", 100, "ForceFeedback", 0, 100);
   config.Set("SDLConstForceThreshold", 30, "ForceFeedback", 0, 100);
 #endif
+  // NetBoard
+  config.Set("Network", false, "Network");
+  config.Set("SimulateNet", true, "Network");
+  config.Set("PortIn", unsigned(1970), "Network");
+  config.Set("PortOut", unsigned(1971), "Network");
+  config.Set<std::string>("AddressOut", "127.0.0.1", "Network", "", "");
 
 #ifdef SUPERMODEL_WIN32
   config.Set<std::string>("Outputs", "none", "Misc", "", "", { "none","win","net" });
@@ -1884,22 +1881,22 @@ static void Help(void)
   puts("  -new-scsp               New SCSP engine based on MAME [Default]");
   puts("  -legacy-scsp            Legacy SCSP engine by ElSemi");
   puts("");
-#ifdef NET_BOARD
   puts("Net Options:");
   puts("  -no-net                 Disable net board [Default]");
   puts("  -net                    Enable net board");
   puts("  -simulate-netboard      Simulate the net board [Default]");
   puts("  -emulate-netboard       Emulate the net board (requires -no-threads)");
   puts("");
-#endif
   puts("Input Options:");
   puts("  -force-feedback         Enable force feedback (DirectInput, XInput)");
   puts("  -config-inputs          Configure keyboards, mice, and game controllers");
 #ifdef SUPERMODEL_WIN32
   printf("  -input-system=<s>       Input system [Default: %s]\n", defaultConfig["InputSystem"].ValueAs<std::string>().c_str());
-  printf("  -outputs=<s>            Outputs [Default: %s]\n", defaultConfig["Outputs"].ValueAs<std::string>().c_str());
 #endif
   puts("  -print-inputs           Prints current input configuration");
+  puts("");
+  puts("Output Options:");
+  printf("  -outputs=<s>            Outputs [Default: %s]\n", defaultConfig["Outputs"].ValueAs<std::string>().c_str());
   puts("");
   puts("Debug Options:");
   puts("  -dump-memory            Write memory regions to files on exit");
@@ -1999,12 +1996,10 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
     { "-new-scsp",            { "LegacySoundDSP",   false } },
     { "-no-white-flash",      { "NoWhiteFlash",     true } },
     { "-white-flash",         { "NoWhiteFlash",     false } },
-#ifdef NET_BOARD
-    { "-net",                 { "Network",       true } },
-    { "-no-net",              { "Network",       false } },
-    { "-simulate-netboard",   { "SimulateNet",   true } },
-    { "-emulate-netboard",    { "SimulateNet",   false } },
-#endif
+    { "-net",                 { "Network",          true } },
+    { "-no-net",              { "Network",          false } },
+    { "-simulate-netboard",   { "SimulateNet",      true } },
+    { "-emulate-netboard",    { "SimulateNet",      false } },
     { "-no-force-feedback",   { "ForceFeedback",    false } },
     { "-force-feedback",      { "ForceFeedback",    true } },
     { "-dump-memory",         { "DumpMemory",       true } },

--- a/Src/OSD/SDL/NetOutputs.cpp
+++ b/Src/OSD/SDL/NetOutputs.cpp
@@ -1,0 +1,307 @@
+/**
+ ** Supermodel
+ ** A Sega Model 3 Arcade Emulator.
+ ** Copyright 2003-2026 The Supermodel Team
+ **
+ ** This file is part of Supermodel.
+ **
+ ** Supermodel is free software: you can redistribute it and/or modify it under
+ ** the terms of the GNU General Public License as published by the Free
+ ** Software Foundation, either version 3 of the License, or (at your option)
+ ** any later version.
+ **
+ ** Supermodel is distributed in the hope that it will be useful, but WITHOUT
+ ** ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ ** FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ ** more details.
+ **
+ ** You should have received a copy of the GNU General Public License along
+ ** with Supermodel.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+#include "NetOutputs.h"
+
+
+CNetOutputs::CNetOutputs()
+{
+}
+
+CNetOutputs::~CNetOutputs()
+{
+    // Unregister all clients and destroy the TCP server socket.
+    UnregisterAllClients();
+    DestroyTcpServerSocket();
+
+    // Stop the server thread.
+    m_running.store(false);
+    if (m_tcpServerThread.joinable()) {
+        m_tcpServerThread.join();
+    }
+
+    // Free up resources.
+    if (m_tcpSocketSet) {
+        SDLNet_FreeSocketSet(m_tcpSocketSet);
+    }
+    if (m_serverSocket) {
+        SDLNet_TCP_Close(m_serverSocket);
+    }
+
+    SDLNet_Quit();
+}
+
+bool CNetOutputs::Initialize()
+{
+    // Create the TCP server socket.
+    if (!CreateTcpServerSocket()) {
+        ErrorLog("Unable to create TCP server socket.");
+        return false;
+    }
+
+    // Run TCP server thread.
+    if (!CreateServerThread()) {
+        ErrorLog("Unable to start thread for TCP server.");
+        return false;
+    }
+
+    return true;
+}
+
+void CNetOutputs::Attached()
+{
+    // Broadcast a startup message.
+    if (!SendUdpBroadcastWithId()) {
+        ErrorLog("Unable to notify with udp broadcast.");
+    }
+}
+
+void CNetOutputs::SendOutput(EOutputs output, UINT8 prevValue, UINT8 value)
+{
+    // Loop through all registered clients and send them new output values.
+    for (auto& client : m_clients) {
+        std::string name = GetOutputName(output);
+        std::string strvalue = std::to_string(value);
+        std::string line = name + m_separatorIdAndValue + strvalue + m_frameEnding;
+        if (!SendTcpData(client, line)) {
+            ErrorLog("Failed to send output data to client. Unregistering client.");
+            UnregisterClient(client.ClientSocket);
+        }
+    }
+}
+
+bool CNetOutputs::CreateServerThread()
+{
+    m_running.store(true);
+    m_tcpServerThread = std::thread([this] {
+        while (m_running.load()) {
+            TCPsocket clientSocket = SDLNet_TCP_Accept(m_serverSocket);
+            if (clientSocket) {
+                // Handle new client connection (e.g., add to list of clients, send initial state, etc.).
+                IPaddress* clientIP = SDLNet_TCP_GetPeerAddress(clientSocket);
+                if (clientIP) {
+                    const char* host = SDLNet_ResolveIP(clientIP);
+                    InfoLog("Client connected from %s:%d", host, clientIP->port);
+                } else {
+                    ErrorLog("Failed to get client IP address: %s", SDLNet_GetError());
+                }
+                RegisterClient(clientSocket);
+            }
+            // Sleep to prevent busy waiting.
+            std::this_thread::sleep_for(std::chrono::milliseconds(16));
+        }
+    });
+    if (!m_tcpServerThread.joinable()) {
+        ErrorLog("Failed to create thread for TCP server.");
+        return false;
+    }
+
+    return true;
+
+}
+
+bool CNetOutputs::CreateTcpServerSocket()
+{
+    SDLNet_Init();
+
+	// Resolve the host (NULL means any host) and port for the server to listen on.
+    IPaddress ip;
+    if (SDLNet_ResolveHost(&ip, NULL, m_tcpPort) == -1) {
+        ErrorLog("ResolveHost error: %s", SDLNet_GetError());
+        return false;
+    }
+
+    // Create the TCP socket and bind it to the specified port.
+    m_serverSocket = SDLNet_TCP_Open(&ip);
+    if (!m_serverSocket) {
+        ErrorLog("TCP_Open error: %s", SDLNet_GetError());
+        return false;
+    }
+
+    // Create the socket set to manage multiple clients.
+    // It is +1 to include the server socket itself.
+    m_tcpSocketSet = SDLNet_AllocSocketSet(m_maxClients + 1);
+    SDLNet_TCP_AddSocket(m_tcpSocketSet, m_serverSocket);
+
+    return true;
+
+}
+
+void CNetOutputs::DestroyTcpServerSocket()
+{
+    if (m_serverSocket) {
+        SDLNet_TCP_Close(m_serverSocket);
+        m_serverSocket = nullptr;
+    }
+}
+
+bool CNetOutputs::SendUdpBroadcastWithId()
+{
+    // Open a UDP socket on any available port.
+    UDPsocket udpSocket = SDLNet_UDP_Open(0);
+    if (!udpSocket) {
+        ErrorLog("UDP_Open error: %s", SDLNet_GetError());
+        return false;
+    }
+
+    // Set up the broadcast address.
+    IPaddress broadcastAddr;
+    if (SDLNet_ResolveHost(&broadcastAddr, "255.255.255.255", m_udpBroadcastPort) == -1) {
+        ErrorLog("ResolveHost error: %s", SDLNet_GetError());
+        return false;
+    }
+
+    // Build the broadcast packet.
+    UDPpacket* packet = SDLNet_AllocPacket(512);
+    std::string lines = "mame_start" + m_separatorIdAndValue + GetGame().name + m_frameEnding + "tcp" + m_separatorIdAndValue + std::to_string(m_tcpPort) + m_frameEnding;
+
+    memcpy(packet->data, lines.c_str(), lines.length());
+    packet->len = lines.length();
+    packet->address = broadcastAddr;
+
+    // Send the broadcast packet.
+    if (SDLNet_UDP_Send(udpSocket, -1, packet) == 0) {
+        ErrorLog("UDP_Send error: %s", SDLNet_GetError());
+    } else {
+        DebugLog("Broadcast sent!");
+    }
+
+    // Clean up.
+    SDLNet_FreePacket(packet);
+    SDLNet_UDP_Close(udpSocket);
+    return true;
+}
+
+bool CNetOutputs::RegisterClient(TCPsocket socket)
+{
+    // Check that given client is not already registered.
+    for (auto& client : m_clients) {
+        if (client.ClientSocket == socket) {
+            // If so, just send it current state of all outputs.
+            SendAllDataToClient(client);
+            return false;
+        }
+    }
+
+    // Add the new client socket to the socket set.
+    SDLNet_TCP_AddSocket(m_tcpSocketSet, socket);
+
+    // If not, store details about client and send it current state of all outputs.
+    RegisteredClientTcp client;
+    client.ClientSocket = socket;
+    m_clients.push_back(client);
+
+    // Send the data to the new client.
+    if (!SendGameIdString(client)) {
+        ErrorLog("Failed to send game id string to client. Unregistering client.");
+        UnregisterClient(socket);
+        return false;
+    }
+    SendAllDataToClient(client);
+
+    return true;
+}
+
+void CNetOutputs::SendAllDataToClient(RegisteredClientTcp& client)
+{
+    // Loop through all known outputs and send their current state to given client.
+    for (unsigned i = 0; i < NUM_OUTPUTS; i++) {
+        EOutputs output = (EOutputs)i;
+        if (HasValue(output)) {
+            std::string name = GetOutputName(output);
+            std::string strvalue = std::to_string(GetValue(output));
+            std::string line = name + m_separatorIdAndValue + strvalue + m_frameEnding;
+            if (!SendTcpData(client, line)) {
+                ErrorLog("Failed to send all output data to client. Unregistering client.");
+                UnregisterClient(client.ClientSocket);
+                break;
+            }
+        }
+    }
+}
+
+bool CNetOutputs::UnregisterAllClients()
+{
+    for (auto& client : m_clients) {
+        UnregisterClient(client.ClientSocket);
+    }
+    m_clients.clear();
+    return true;
+}
+
+bool CNetOutputs::UnregisterClient(TCPsocket socket)
+{
+    // Find any matching clients and remove them.
+    bool found = false;
+    std::vector<RegisteredClientTcp>::iterator it = m_clients.begin();
+    while (it != m_clients.end()) {
+        if (it->ClientSocket == socket) {
+            // Client found, send stop message and remove it.
+            SendStopString(*it, true);
+            it = m_clients.erase(it);
+            found = true;
+            // Remove from socket set and close the socket.
+            SDLNet_TCP_DelSocket(m_tcpSocketSet, socket);
+            SDLNet_TCP_Close(socket);
+        } else {
+            it++;
+        }
+    }
+
+    // Return error if no matches found.
+    return found;
+}
+
+bool CNetOutputs::SendGameIdString(RegisteredClientTcp& client)
+{
+    std::string line = "mame_start" + m_separatorIdAndValue + GetGame().name + m_frameEnding;
+    return SendTcpData(client, line);
+}
+
+bool CNetOutputs::SendStopString(RegisteredClientTcp& client, bool stopped)
+{
+    std::string line = "mame_stop" + m_separatorIdAndValue + std::string((stopped ? "1" : "0")) + m_frameEnding;
+    return SendTcpData(client, line);
+}
+
+bool CNetOutputs::SendPauseString(RegisteredClientTcp& client, bool paused)
+{
+    std::string line = "pause" + m_separatorIdAndValue + std::string((paused ? "1" : "0")) + m_frameEnding;
+    return SendTcpData(client, line);
+}
+
+bool CNetOutputs::SendTcpData(RegisteredClientTcp& client, const std::string& data)
+{
+    auto sentDataLen = SDLNet_TCP_Send(client.ClientSocket, data.c_str(), data.length());
+    DebugLog("Sent to client: %s", data.c_str());
+    DebugLog("Bytes sent: %d", sentDataLen);
+    DebugLog("Expected bytes: %zu", data.length());
+    // Check for errors in sending data.
+    if (sentDataLen < static_cast<int>(data.length())) {
+        ErrorLog("Failed to send TCP data to client: %s (tried to send %zu bytes, sent %d bytes).",
+            SDLNet_GetError(),
+            data.length(),
+            sentDataLen
+        );
+        return false;
+    }
+    return true;
+}

--- a/Src/OSD/SDL/NetOutputs.h
+++ b/Src/OSD/SDL/NetOutputs.h
@@ -1,0 +1,199 @@
+/**
+ ** Supermodel
+ ** A Sega Model 3 Arcade Emulator.
+ ** Copyright 2003-2026 The Supermodel Team
+ **
+ ** This file is part of Supermodel.
+ **
+ ** Supermodel is free software: you can redistribute it and/or modify it under
+ ** the terms of the GNU General Public License as published by the Free
+ ** Software Foundation, either version 3 of the License, or (at your option)
+ ** any later version.
+ **
+ ** Supermodel is distributed in the hope that it will be useful, but WITHOUT
+ ** ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ ** FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ ** more details.
+ **
+ ** You should have received a copy of the GNU General Public License along
+ ** with Supermodel.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+ /*
+  * NetOutputs.h
+  *
+  * Implementation of COutputs that sends MAMEHooker compatible messages via TCP and UDP.
+  */
+
+#pragma once
+
+#include "Logger.h"
+#include "Outputs.h"
+#include "SDLIncludes.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <atomic>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+// Default values for configurable settings.
+const unsigned int NET_OUTPUTS_DEFAULT_TCP_PORT = 8000;
+const unsigned int NET_OUTPUTS_DEFAULT_UDP_BROADCAST_PORT = 8001;
+const std::string NET_OUTPUTS_DEFAULT_FRAME_ENDING = std::string("\r");
+const std::string NET_OUTPUTS_DEFAULT_SEPARATOR_ID_AND_VALUE = std::string(" = ");
+
+// Maximum number of clients that can be registered with the emulator at once.
+// This was chosen somewhat arbitrarily, but seems reasonable given the use
+// case of MAMEHooker and similar tools.
+const unsigned int NET_OUTPUTS_MAX_CLIENTS = 10;
+
+// Struct that represents a client (eg MAMEHooker) currently registered with the emulator.
+struct RegisteredClientTcp
+{
+	TCPsocket ClientSocket;
+};
+
+
+class CNetOutputs : public COutputs
+{
+public:
+	/*
+	 * CNetOutputs():
+	 * ~CNetOutputs():
+	 *
+	 * Constructor and destructor.
+	 */
+	CNetOutputs();
+	virtual ~CNetOutputs();
+
+	/*
+	 * Initialize():
+	 *
+	 * Initializes this class.
+	 */
+	bool Initialize();
+
+	/*
+	 * Attached():
+	 *
+	 * Lets the class know that it has been attached to the emulator.
+	 */
+	void Attached();
+
+	void SetFrameEnding(const std::string& ending) { m_frameEnding = ending; }
+	void SetTcpPort(unsigned int port) { m_tcpPort = port; }
+	void SetUdpBroadcastPort(unsigned int port) { m_udpBroadcastPort = port; }
+protected:
+	/*
+	 * SendOutput():
+	 *
+	 * Sends the appropriate output message to all registered clients.
+	 */
+	void SendOutput(EOutputs output, UINT8 prevValue, UINT8 value);
+
+private:
+	// Configurable values.
+	unsigned int m_tcpPort = NET_OUTPUTS_DEFAULT_TCP_PORT;
+	unsigned int m_udpBroadcastPort = NET_OUTPUTS_DEFAULT_UDP_BROADCAST_PORT;
+	 // Defaults to "\r", can also be "\r\n", see configuration.
+	std::string m_frameEnding = NET_OUTPUTS_DEFAULT_FRAME_ENDING;
+
+	// Internal data.
+	std::string m_separatorIdAndValue = NET_OUTPUTS_DEFAULT_SEPARATOR_ID_AND_VALUE;
+	unsigned int m_maxClients = NET_OUTPUTS_MAX_CLIENTS;
+	std::atomic<bool> m_running = false;
+	std::vector<RegisteredClientTcp> m_clients{};
+	TCPsocket m_serverSocket;
+    SDLNet_SocketSet m_tcpSocketSet;
+	std::thread m_tcpServerThread;
+
+	/*
+	 * CreateServerThread():
+	 *
+	 * Wait for new client and handle it appropriately.
+	 */
+	bool CreateServerThread();
+
+	/*
+	 * CreateTcpServerSocket():
+	 *
+	 * Creates the TCP server socket.
+	 */
+	bool CreateTcpServerSocket();
+
+	/*
+	 * DestroyTcpServerSocket():
+	 *
+	 * Destroys the TCP server socket.
+	 */
+	void DestroyTcpServerSocket();
+
+	/*
+	 * SendUdpBroadcastWithId():
+	 *
+	 * Broadcasts a message over UDP to show that the emulator is running and to provide
+	 * the TCP port number.
+	 */
+	bool SendUdpBroadcastWithId();
+
+	/*
+	 * RegisterClient(hwnd, id):
+	 *
+	 * Registers a client (eg MAMEHooker) with the emulator.
+	 */
+	bool RegisterClient(TCPsocket socket);
+
+	/*
+	 * SendAllToClient(client):
+	 *
+	 * Sends the current state of all the outputs to the given registered client.
+	 * Called whenever a client is registered with the emulator.
+	 */
+	void SendAllDataToClient(RegisteredClientTcp& client);
+
+	/*
+	 * UnregisterClient(hwnd, id):
+	 *
+	 * Unregisters a client from the emulator.
+	 */
+	bool UnregisterClient(TCPsocket socket);
+
+	/*
+	 * UnregisterAllClients():
+	 *
+	 * Unregisters all clients from the emulator.
+	*/
+	bool UnregisterAllClients();
+
+	/*
+	 * SendGameIdString(hwnd, id):
+	 *
+	 * Sends the name of the current running game.
+	 */
+	bool SendGameIdString(RegisteredClientTcp& client);
+
+	/*
+	 * SendStopString(hwnd, id):
+	 *
+	 * Sends the mame stops message.
+	 */
+	bool SendStopString(RegisteredClientTcp& client, bool stopped);
+
+	/*
+	* SendPauseString(hwnd, id):
+	 *
+	 * Sends the name of the current running game.
+	 */
+	bool SendPauseString(RegisteredClientTcp& client, bool paused);
+
+	/*
+	 * SendTcpData(client, data):
+	 *
+	 * Sends the given data string to the given client over TCP.
+	 */
+	bool SendTcpData(RegisteredClientTcp& client, const std::string& data);
+};
+

--- a/Src/OSD/SDL/SDLIncludes.h
+++ b/Src/OSD/SDL/SDLIncludes.h
@@ -37,12 +37,10 @@
 #include <SDL_audio.h>
 #endif
 
-#ifdef NET_BOARD
 #ifdef SUPERMODEL_OSX
 #include <SDL2_net/SDL_net.h>
 #else
 #include <SDL_net.h>
-#endif
 #endif
 
 #endif  // INCLUDED_SDLINCLUDES_H

--- a/VS2008/Supermodel.vcproj
+++ b/VS2008/Supermodel.vcproj
@@ -2099,6 +2099,10 @@
 						RelativePath="..\Src\OSD\SDL\Types.h"
 						>
 					</File>
+					<File
+						RelativePath="..\Src\OSD\SDL\NetOutputs.h"
+						>
+					</File>
 				</Filter>
 				<Filter
 					Name="Windows"

--- a/VS2008/Supermodel.vcxproj
+++ b/VS2008/Supermodel.vcxproj
@@ -570,6 +570,7 @@ xcopy /D /Y "$(ProjectDir)..\Assets\*" "$(TargetDir)Assets"</Command>
     <ClInclude Include="..\Src\OSD\Video.h" />
     <ClInclude Include="..\Src\OSD\Windows\DirectInputSystem.h" />
     <ClInclude Include="..\Src\OSD\Windows\WinOutputs.h" />
+    <ClInclude Include="..\Src\OSD\SDL\NetOutputs.h" />
     <ClInclude Include="..\Src\Pkgs\glew.h" />
     <ClInclude Include="..\Src\Pkgs\glxew.h" />
     <ClInclude Include="..\Src\Pkgs\imgui\imconfig.h" />

--- a/VS2008/Supermodel.vcxproj
+++ b/VS2008/Supermodel.vcxproj
@@ -94,7 +94,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\Src;..\Src\OSD;..\Src\OSD\SDL;..\Src\OSD\Windows;..\Libraries\zlib-1.2.4;..\Libraries\SDL2-2.30.8\include;..\Libraries\SDL2_net-2.2.0;$(DXSDK_DIR)\Include;..\Src\Pkgs;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>SUPERMODEL_WIN32;INLINE=static __inline;_MBCS;_CRT_SECURE_NO_WARNINGS;GLEW_STATIC;NET_BOARD</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SUPERMODEL_WIN32;INLINE=static __inline;_MBCS;_CRT_SECURE_NO_WARNINGS;GLEW_STATIC</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -131,7 +131,7 @@ xcopy /D /Y "$(ProjectDir)..\Assets\*" "$(TargetDir)Assets"</Command>
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\Src;..\Src\OSD;..\Src\OSD\SDL;..\Src\OSD\Windows;..\Libraries\zlib-1.2.4;..\Libraries\SDL2-2.30.8\include;..\Libraries\SDL2_net-2.2.0;$(DXSDK_DIR)\Include;..\Src\Pkgs;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>SUPERMODEL_WIN32;INLINE=static __inline;_MBCS;_CRT_SECURE_NO_WARNINGS;GLEW_STATIC;NET_BOARD</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SUPERMODEL_WIN32;INLINE=static __inline;_MBCS;_CRT_SECURE_NO_WARNINGS;GLEW_STATIC</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -166,7 +166,7 @@ xcopy /D /Y "$(ProjectDir)..\Assets\*" "$(TargetDir)Assets"</Command>
       <Optimization>Full</Optimization>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <AdditionalIncludeDirectories>..\Src;..\Src\OSD;..\Src\OSD\SDL;..\Src\OSD\Windows;..\Libraries\zlib-1.2.4;..\Libraries\SDL2-2.30.8\include;..\Libraries\SDL2_net-2.2.0;$(DXSDK_DIR)\Include;..\Src\Pkgs;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>SUPERMODEL_WIN32;INLINE=static __inline;_MBCS;_CRT_SECURE_NO_WARNINGS;GLEW_STATIC;NET_BOARD</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SUPERMODEL_WIN32;INLINE=static __inline;_MBCS;_CRT_SECURE_NO_WARNINGS;GLEW_STATIC</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader />
@@ -205,7 +205,7 @@ xcopy /D /Y "$(ProjectDir)..\Assets\*" "$(TargetDir)Assets"</Command>
       <Optimization>Full</Optimization>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <AdditionalIncludeDirectories>..\Src;..\Src\OSD;..\Src\OSD\SDL;..\Src\OSD\Windows;..\Libraries\zlib-1.2.4;..\Libraries\SDL2-2.30.8\include;..\Libraries\SDL2_net-2.2.0;$(DXSDK_DIR)\Include;..\Src\Pkgs;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>SUPERMODEL_WIN32;INLINE=static __inline;_MBCS;_CRT_SECURE_NO_WARNINGS;GLEW_STATIC;NET_BOARD</PreprocessorDefinitions>
+      <PreprocessorDefinitions>SUPERMODEL_WIN32;INLINE=static __inline;_MBCS;_CRT_SECURE_NO_WARNINGS;GLEW_STATIC</PreprocessorDefinitions>
       <ExceptionHandling>Sync</ExceptionHandling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/VS2008/Supermodel.vcxproj.filters
+++ b/VS2008/Supermodel.vcxproj.filters
@@ -637,6 +637,9 @@
     <ClInclude Include="..\Src\OSD\Windows\WinOutputs.h">
       <Filter>Header Files\OSD\Windows</Filter>
     </ClInclude>
+    <ClInclude Include="..\Src\OSD\SDL\NetOutputs.h">
+      <Filter>Header Files\OSD\SDL</Filter>
+    </ClInclude>
     <ClInclude Include="..\Src\Pkgs\glew.h">
       <Filter>Header Files\Pkgs</Filter>
     </ClInclude>


### PR DESCRIPTION
This pull request adds a new network-based output system to the SDL build, allowing output messages to be sent over TCP and UDP for integration with tools like MAMEHooker.

This is meant as a successor of the following PR: #253
Successfully tested with Daytona 2, LA Machineguns, Lost World, SW Trilogy.
~~So far tests only on Linux, waiting for the build system to produce a Windows build.~~
Tested on Windows with Hook Of The Reaper and QMameHooker / custom scripts / Wireshark on Linux.
~~Updating docs will follow before leaving draft state.~~
Docs updated.

NET_BOARD define removed to always enable netboard support.


PR summary (Copilot):

**Network Output System Integration:**

* Added new files `NetOutputs.cpp` and `NetOutputs.h` implementing the `CNetOutputs` class, which sends output messages over TCP and UDP in a MAMEHooker-compatible format. This includes client registration, data transmission, and UDP broadcast for discovery. [[1]](diffhunk://#diff-10695a4960eced7a9628a922fdf4772f22d4c86b2c9bd67bcaa1e8e204ddfc5eR1-R307) [[2]](diffhunk://#diff-cc998779d77c41ebad4dc69391210b566f151129281c562ebb6e5200e40143d1R1-R191)
* Updated `Main.cpp` to support selecting the "net" output system via configuration, including instantiation, initialization, and configuration of TCP/UDP ports and line endings. [[1]](diffhunk://#diff-654aabc47451bf06a0596aa3665e066ce388efac00b6c1db5106b3ddd7a849d7L2410-L2424) [[2]](diffhunk://#diff-654aabc47451bf06a0596aa3665e066ce388efac00b6c1db5106b3ddd7a849d7R81)

**Configuration Enhancements:**

* Added new configuration options: `OutputsWithLF` (line ending), `OutputsTCPPort`, and `OutputsUDPBroadcastPort` to control network output behavior.

**Build System and Project File Updates:**

* Included `NetOutputs.cpp` in the SDL source file list for building.
* Added `NetOutputs.h` to the Visual Studio project and filter files, ensuring proper inclusion in the build environment. [[1]](diffhunk://#diff-7bb63f447a48bfcb1dd9ee93397d6ea7e59c77d8f3328aa74b6e5317ed9cd075R2102-R2105) [[2]](diffhunk://#diff-84a29ed1dd376171e051469c3e00b26ff28048d95f09859e370066284798d83cR573) [[3]](diffhunk://#diff-94ed9274b7afd7b066efbd30bdb70a7bc7481b16ebe50864352295028521e217R640-R642)