### PR TITLE
Code cleanup to fix warnings on Windows and macOS builds, added -dump-memory option

### DIFF
--- a/Makefiles/Makefile.OSX
+++ b/Makefiles/Makefile.OSX
@@ -102,6 +102,9 @@ PLATFORM_SRC_FILES = \
 
 include Makefiles/Rules.inc
 
+# -s (strip) is obsolete and ignored by Apple ld64; remove it to avoid potential warnings
+LDOPT := $(filter-out -s,$(LDOPT))
+
 # Suppress gluPerspective deprecation warnings (macOS only, deprecated since 10.9)
 $(OBJ_DIR)/Legacy3D.o: CXXFLAGS += -Wno-deprecated-declarations
 

--- a/Makefiles/Makefile.OSX
+++ b/Makefiles/Makefile.OSX
@@ -1,7 +1,7 @@
 ##
 ## Supermodel
 ## A Sega Model 3 Arcade Emulator.
-## Copyright 2003-2025 The Supermodel Team
+## Copyright 2003-2026 The Supermodel Team
 ##
 ## This file is part of Supermodel.
 ##
@@ -101,6 +101,9 @@ PLATFORM_SRC_FILES = \
 	Src/OSD/OSX/FileSystemPath.cpp
 
 include Makefiles/Rules.inc
+
+# Suppress gluPerspective deprecation warnings (macOS only, deprecated since 10.9)
+$(OBJ_DIR)/Legacy3D.o: CXXFLAGS += -Wno-deprecated-declarations
 
 clean:
 	$(SILENT)echo Cleaning up \"Frameworks\", \"$(BIN_DIR)\" and \"$(OBJ_DIR)\"...

--- a/Makefiles/Rules.inc
+++ b/Makefiles/Rules.inc
@@ -367,6 +367,9 @@ $(OBJ_DIR)/%.o:	%.cpp | $(OBJ_DIR)
 	$(info Compiling              : $< -> $@)
 	$(SILENT)$(CXX) $(CXXFLAGS) $< -o $@
 
+# Suppress all warnings for third-party packages that we cannot modify
+$(OBJ_DIR)/glew.o: CFLAGS += -w
+
 $(OBJ_DIR)/%.o:	%.c | $(OBJ_DIR)
 	$(info Generating dependencies: $< -> $(OBJ_DIR)/$(*F).d)
 	$(SILENT)$(CC) -MM -MP -MT $(OBJ_DIR)/$(*F).o -MT $(OBJ_DIR)/$(*F).d $(CFLAGS) $< > $(OBJ_DIR)/$(*F).d

--- a/Src/CPU/68K/Musashi/m68kcpu.c
+++ b/Src/CPU/68K/Musashi/m68kcpu.c
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson 
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **

--- a/Src/CPU/68K/Musashi/m68kctx.h
+++ b/Src/CPU/68K/Musashi/m68kctx.h
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson 
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **
@@ -72,7 +72,7 @@ typedef struct
 	UINT32 cyc_shift;
 	UINT32 cyc_reset;
 	UINT8* cyc_instruction;
-	UINT8* cyc_exception;
+	const UINT8* cyc_exception;
 
 	/* Callbacks to host */
 	int  (*int_ack_callback)(int int_line);           /* Interrupt Acknowledge */

--- a/Src/CPU/68K/Musashi/m68kmake.c
+++ b/Src/CPU/68K/Musashi/m68kmake.c
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson 
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **
@@ -698,7 +698,11 @@ opcode_struct* find_opcode(char* name, int size, char* spec_proc, char* spec_ea)
 	opcode_struct* op;
 
 
-	for(op = g_opcode_input_table;op->name != NULL;op++)
+	/* Note: original Musashi code used 'op->name != NULL' here, but op->name is a char array
+	 * (not a pointer), so that comparison is always true and would loop forever if no match
+	 * were found. In practice the loop always exits early via 'return op'. The correct
+	 * sentinel check is an empty name string from the zero-initialized table. */
+	for(op = g_opcode_input_table;op->name[0] != '\0';op++)
 	{
 		if(	strcmp(name, op->name) == 0 &&
 			(size == op->size) &&
@@ -714,7 +718,11 @@ opcode_struct* find_illegal_opcode(void)
 {
 	opcode_struct* op;
 
-	for(op = g_opcode_input_table;op->name != NULL;op++)
+	/* Note: original Musashi code used 'op->name != NULL' here, but op->name is a char array
+	 * (not a pointer), so that comparison is always true and would loop forever if no match
+	 * were found. In practice the loop always exits early via 'return op'. The correct
+	 * sentinel check is an empty name string from the zero-initialized table. */
+	for(op = g_opcode_input_table;op->name[0] != '\0';op++)
 	{
 		if(strcmp(op->name, "illegal") == 0)
 			return op;

--- a/Src/CPU/PowerPC/PPCDisasm.cpp
+++ b/Src/CPU/PowerPC/PPCDisasm.cpp
@@ -1230,7 +1230,7 @@ int main(int argc, char **argv)
      * Disassemble!
      */
 
-    for (unsigned i = start; i < fsize && i < (start + len); i += 4, org += 4)
+    for (unsigned i = start; i < fsize && i < (start + len) && (i + 4) <= fsize; i += 4, org += 4)
     {
         if (!little)
             op = (buffer[i] << 24) | (buffer[i + 1] << 16) |

--- a/Src/CPU/PowerPC/PPCDisasm.h
+++ b/Src/CPU/PowerPC/PPCDisasm.h
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **
@@ -54,7 +54,7 @@
  *      OKAY if successful, FAIL if the instruction was unrecognized or had an
  *      invalid form (see note above in function description.)
  */ 
-extern Result DisassemblePowerPC(UINT32 op, UINT32 vpc, char *mnem, char *oprs,
+extern Result DisassemblePowerPC(UINT32 op, UINT32 vpc, char *mnem, char *oprs, size_t oprs_size,
                         	   bool simplify);
 
 #endif	// INCLUDED_PPCDISASM_H

--- a/Src/CPU/PowerPC/ppc.cpp
+++ b/Src/CPU/PowerPC/ppc.cpp
@@ -664,7 +664,7 @@ static void (* optable[64])(UINT32);
 
 void ppc_base_init(void)
 {
-	int i,j;
+	size_t i,j;
 
 	memset(&ppc, 0, sizeof(ppc));
 

--- a/Src/CPU/PowerPC/ppc.cpp
+++ b/Src/CPU/PowerPC/ppc.cpp
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **
@@ -638,18 +638,6 @@ static inline void ppc_set_msr(UINT32 value)
 static inline UINT32 ppc_get_msr(void)
 {
 	return MSR;
-}
-
-static inline void ppc_set_cr(UINT32 value)
-{
-	CR(0) = (value >> 28) & 0xf;
-	CR(1) = (value >> 24) & 0xf;
-	CR(2) = (value >> 20) & 0xf;
-	CR(3) = (value >> 16) & 0xf;
-	CR(4) = (value >> 12) & 0xf;
-	CR(5) = (value >> 8) & 0xf;
-	CR(6) = (value >> 4) & 0xf;
-	CR(7) = (value >> 0) & 0xf;
 }
 
 static inline UINT32 ppc_get_cr(void)

--- a/Src/CPU/PowerPC/ppc603.c
+++ b/Src/CPU/PowerPC/ppc603.c
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **
@@ -271,7 +271,7 @@ int ppc_execute(int cycles)
 		char string1[200];
 		char string2[200];
 		opcode = BSWAP32(*ppc.op);
-		DisassemblePowerPC(opcode, ppc.npc, string1, string2, true);
+		DisassemblePowerPC(opcode, ppc.npc, string1, string2, sizeof(string2), true);
 		printf("%08X: %s %s\n", ppc.npc, string1, string2);
 	}*/
 
@@ -341,7 +341,7 @@ int ppc_execute(int cycles)
 		char string1[200];
 		char string2[200];
 		opcode = BSWAP32(*ppc.op);
-		DisassemblePowerPC(opcode, ppc.npc, string1, string2, true);
+		DisassemblePowerPC(opcode, ppc.npc, string1, string2, sizeof(string2), true);
 		printf("%08X: %s %s\n", ppc.npc, string1, string2);
 	}
 	*/

--- a/Src/CPU/Z80/Z80.cpp
+++ b/Src/CPU/Z80/Z80.cpp
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **

--- a/Src/CPU/Z80/Z80.cpp
+++ b/Src/CPU/Z80/Z80.cpp
@@ -2270,7 +2270,6 @@ int CZ80::Run(int numCycles)
       break;
     case 0xCB:      /* CB prefix */
       adr = IX + (signed char) GetBYTE_pp(pc);
-      adr = adr;
       op = GetBYTE(pc);
       cycles -= cycleTables[4][op];
       switch (op & 7) {
@@ -3505,7 +3504,6 @@ int CZ80::Run(int numCycles)
       break;
     case 0xCB:      /* CB prefix */
       adr = IY + (signed char) GetBYTE_pp(pc);
-      adr = adr;
       op = GetBYTE(pc);
       cycles -= cycleTables[4][op];
       switch (op & 7) {

--- a/Src/Debugger/CPU/PPCDebug.cpp
+++ b/Src/Debugger/CPU/PPCDebug.cpp
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **
@@ -270,7 +270,7 @@ namespace Debugger
 		char valStr[40];
 		UINT32 opcode = m_bus->Read32(addr);
 		operands[0] = '\0';
-		if (DisassemblePowerPC(opcode, addr, mnemonic, opStr, true) == Result::OKAY)
+		if (DisassemblePowerPC(opcode, addr, mnemonic, opStr, sizeof(opStr), true) == Result::OKAY)
 		{
 			char *o = opStr;
 			char *s = strstr(o, "0x");

--- a/Src/GameLoader.cpp
+++ b/Src/GameLoader.cpp
@@ -136,7 +136,11 @@ bool GameLoader::MissingAttrib(const GameLoader &loader, const Util::Config::Nod
 
 GameLoader::File::ptr_t GameLoader::File::Create(const GameLoader &loader, const Util::Config::Node &file_node)
 {
-  if (GameLoader::MissingAttrib(loader, file_node, "name") | GameLoader::MissingAttrib(loader, file_node, "offset")) // no || to easier detect errors
+  // Evaluate separately (not in a single expression) to avoid short-circuit evaluation,
+  // ensuring all missing attributes are detected and reported.
+  bool missingName = GameLoader::MissingAttrib(loader, file_node, "name");
+  bool missingOffset = GameLoader::MissingAttrib(loader, file_node, "offset");
+  if (missingName || missingOffset)
     return ptr_t();
   ptr_t file = std::make_shared<File>();
   file->offset = file_node["offset"].ValueAs<uint32_t>();
@@ -160,7 +164,12 @@ bool GameLoader::File::operator==(const File &rhs) const
 
 GameLoader::Region::ptr_t GameLoader::Region::Create(const GameLoader &loader, const Util::Config::Node &region_node)
 {
-  if (GameLoader::MissingAttrib(loader, region_node, "name") | MissingAttrib(loader, region_node, "stride") | GameLoader::MissingAttrib(loader, region_node, "chunk_size")) // no || to easier detect errors
+  // Evaluate separately (not in a single expression) to avoid short-circuit evaluation,
+  // ensuring all missing attributes are detected and reported.
+  bool missingName = GameLoader::MissingAttrib(loader, region_node, "name");
+  bool missingStride = MissingAttrib(loader, region_node, "stride");
+  bool missingChunkSize = GameLoader::MissingAttrib(loader, region_node, "chunk_size");
+  if (missingName || missingStride || missingChunkSize)
     return ptr_t();
 
   if (region_node["byte_swap"].Exists() && region_node["byte_layout"].Exists())

--- a/Src/Graphics/Legacy3D/Legacy3D.cpp
+++ b/Src/Graphics/Legacy3D/Legacy3D.cpp
@@ -1184,7 +1184,7 @@ Result CLegacy3D::SetupGLObjects()
     for (int mapNum = 0; mapNum < 8 && mapCount < maxTexMaps; mapNum++)
     {
         char uniformName[12];
-        sprintf(uniformName, "textureMap%u", mapNum);
+        snprintf(uniformName, sizeof(uniformName), "textureMap%u", mapNum);
         textureMapLocs[mapNum] = glGetUniformLocation(shaderProgram, uniformName);
         // If exist, bind to remaining texture units
         if (textureMapLocs[mapNum] != -1)

--- a/Src/Graphics/Legacy3D/Models.cpp
+++ b/Src/Graphics/Legacy3D/Models.cpp
@@ -999,7 +999,6 @@ struct VBORef *CLegacy3D::CacheModel(ModelCache *Cache, int lutIdx, UINT16 textu
   
   // Cache all polygons
   Vertex    Prev[4];  // previous vertices
-  int       numPolys = 0;
   bool      useStencil = true;
   bool      done = false;
   while (!done)
@@ -1135,7 +1134,6 @@ struct VBORef *CLegacy3D::CacheModel(ModelCache *Cache, int lutIdx, UINT16 textu
       // Copy this polygon into the model buffer
       if (Result::OKAY != InsertPolygon(Cache,&P))
         return NULL;
-      ++numPolys;
     }
   }
   

--- a/Src/Graphics/New3D/Model.h
+++ b/Src/Graphics/New3D/Model.h
@@ -9,21 +9,20 @@
 
 namespace New3D {
 
-struct Vertex					// half vertex
+// Helper struct providing only static methods. Must not have any members in order for offsetof to
+// work on vertex structs that inherit this.
+struct VertexHelpers
 {
-	float pos[4];
-	float normal[3];
-	float texcoords[2];
-	float fixedShade;
-
-	static bool Equal(const Vertex& p1, const Vertex& p2)
+	template <typename VertexLike>
+	static bool Equal(const VertexLike& p1, const VertexLike& p2)
 	{
 		return (p1.pos[0] == p2.pos[0] &&
 			p1.pos[1] == p2.pos[1] &&
 			p1.pos[2] == p2.pos[2]);
 	}
 
-	static void Average(const Vertex& p1, const Vertex& p2, Vertex& p3)
+	template <typename VertexLike1, typename VertexLike2>
+	static void Average(const VertexLike1& p1, const VertexLike1& p2, VertexLike2& p3)
 	{
 		p3.pos[3] = 1.0f;	//always 1
 		p3.fixedShade = (p1.fixedShade + p2.fixedShade) * 0.5f;
@@ -32,6 +31,14 @@ struct Vertex					// half vertex
 		for (int i = 0; i < 3; i++)	{ p3.normal[i] = (p1.normal[i] + p2.normal[i]) * 0.5f; }
 		for (int i = 0; i < 2; i++)	{ p3.texcoords[i] = (p1.texcoords[i] + p2.texcoords[i]) * 0.5f; }
 	}
+};
+
+struct Vertex: VertexHelpers	// half vertex
+{
+	float pos[4];
+	float normal[3];
+	float texcoords[2];
+	float fixedShade;
 };
 
 struct R3DPoly
@@ -43,8 +50,13 @@ struct R3DPoly
 	int number = 4;
 };
 
-struct FVertex : Vertex			// full vertex including face attributes
+struct FVertex: VertexHelpers	// full vertex including face attributes
 {
+	float pos[4];
+	float normal[3];
+	float texcoords[2];
+	float fixedShade;
+
 	float faceNormal[3];
 	UINT8 faceColour[4];
 	float textureNP;

--- a/Src/Graphics/New3D/New3D.cpp
+++ b/Src/Graphics/New3D/New3D.cpp
@@ -18,13 +18,13 @@
 namespace New3D {
 
 CNew3D::CNew3D(const Util::Config::Node &config, const std::string& gameName) : 
-	m_r3dShader(config),
-	m_r3dScrollFog(config),
 	m_gameName(gameName),
-	m_vao(0),
-	m_aaTarget(0),
-	m_LODBlendTable(nullptr),
-	m_matrixBasePtr(nullptr),
+	m_blockCulling(false),
+	m_cullingRAMLo(nullptr),
+	m_cullingRAMHi(nullptr),
+	m_polyRAM(nullptr),
+	m_vrom(nullptr),
+	m_textureRAM(nullptr),
 	m_xRatio(0),
 	m_yRatio(0),
 	m_xOffs(0),
@@ -34,14 +34,14 @@ CNew3D::CNew3D(const Util::Config::Node &config, const std::string& gameName) :
 	m_totalXRes(0),
 	m_totalYRes(0),
 	m_wideScreen(false),
-	m_cullingRAMLo(nullptr),
-	m_cullingRAMHi(nullptr),
-	m_polyRAM(nullptr),
-	m_vrom(nullptr),
-	m_textureRAM(nullptr),
-	m_prev{ 0 },
-	m_prevTexCoords{ 0 },
-	m_blockCulling(false)
+	m_matrixBasePtr(nullptr),
+	m_LODBlendTable(nullptr),
+	m_prev{{}},
+	m_prevTexCoords{{}},
+	m_vao(0),
+	m_r3dShader(config),
+	m_r3dScrollFog(config),
+	m_aaTarget(0)
 {
 	m_sunClamp		= true;
 	m_numPolyVerts	= 3;

--- a/Src/Graphics/New3D/New3D.cpp
+++ b/Src/Graphics/New3D/New3D.cpp
@@ -1,3 +1,24 @@
+/**
+ ** Supermodel
+ ** A Sega Model 3 Arcade Emulator.
+ ** Copyright 2003-2026 The Supermodel Team
+ **
+ ** This file is part of Supermodel.
+ **
+ ** Supermodel is free software: you can redistribute it and/or modify it under
+ ** the terms of the GNU General Public License as published by the Free
+ ** Software Foundation, either version 3 of the License, or (at your option)
+ ** any later version.
+ **
+ ** Supermodel is distributed in the hope that it will be useful, but WITHOUT
+ ** ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ ** FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ ** more details.
+ **
+ ** You should have received a copy of the GNU General Public License along
+ ** with Supermodel.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+
 #include "New3D.h"
 #include "Vec.h"
 #include <cmath>
@@ -40,7 +61,7 @@ CNew3D::CNew3D(const Util::Config::Node &config, const std::string& gameName) :
 	m_prevTexCoords{{}},
 	m_vao(0),
 	m_r3dShader(config),
-	m_r3dScrollFog(config),
+	m_r3dScrollFog(),
 	m_aaTarget(0)
 {
 	m_sunClamp		= true;

--- a/Src/Graphics/New3D/New3D.cpp
+++ b/Src/Graphics/New3D/New3D.cpp
@@ -96,11 +96,11 @@ CNew3D::CNew3D(const Util::Config::Node &config, const std::string& gameName) :
 
 	// before draw, specify vertex and index arrays with their offsets, offsetof is maybe evil ..
 	glVertexAttribPointer(m_r3dShader.GetVertexAttribPos("inVertex"), 4, GL_FLOAT, GL_FALSE, sizeof(FVertex), 0);
-	glVertexAttribPointer(m_r3dShader.GetVertexAttribPos("inNormal"), 3, GL_FLOAT, GL_FALSE, sizeof(FVertex), (void*)offsetof(FVertex, normal));
-	glVertexAttribPointer(m_r3dShader.GetVertexAttribPos("inTexCoord"), 2, GL_FLOAT, GL_FALSE, sizeof(FVertex), (void*)offsetof(FVertex, texcoords));
+	glVertexAttribPointer(m_r3dShader.GetVertexAttribPos("inNormal"), 3, GL_FLOAT, GL_FALSE, sizeof(FVertex), (void*)offsetof(FVertex, base.normal));
+	glVertexAttribPointer(m_r3dShader.GetVertexAttribPos("inTexCoord"), 2, GL_FLOAT, GL_FALSE, sizeof(FVertex), (void*)offsetof(FVertex, base.texcoords));
 	glVertexAttribPointer(m_r3dShader.GetVertexAttribPos("inColour"), 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(FVertex), (void*)offsetof(FVertex, faceColour));
 	glVertexAttribPointer(m_r3dShader.GetVertexAttribPos("inFaceNormal"), 3, GL_FLOAT, GL_FALSE, sizeof(FVertex), (void*)offsetof(FVertex, faceNormal));
-	glVertexAttribPointer(m_r3dShader.GetVertexAttribPos("inFixedShade"), 1, GL_FLOAT, GL_FALSE, sizeof(FVertex), (void*)offsetof(FVertex, fixedShade));
+	glVertexAttribPointer(m_r3dShader.GetVertexAttribPos("inFixedShade"), 1, GL_FLOAT, GL_FALSE, sizeof(FVertex), (void*)offsetof(FVertex, base.fixedShade));
 	glVertexAttribPointer(m_r3dShader.GetVertexAttribPos("inTextureNP"), 1, GL_FLOAT, GL_FALSE, sizeof(FVertex), (void*)offsetof(FVertex, textureNP));
 
 	glBindVertexArray(0);

--- a/Src/Graphics/New3D/R3DFrameBuffers.cpp
+++ b/Src/Graphics/New3D/R3DFrameBuffers.cpp
@@ -183,6 +183,10 @@ void R3DFrameBuffers::SetFBO(Layer layer)
 		glDrawBuffer(GL_BACK);
 		break;
 	}
+	default:
+	{
+		break;
+	}
 	}
 
 	m_lastLayer = layer;

--- a/Src/Graphics/New3D/R3DScrollFog.cpp
+++ b/Src/Graphics/New3D/R3DScrollFog.cpp
@@ -1,3 +1,24 @@
+/**
+ ** Supermodel
+ ** A Sega Model 3 Arcade Emulator.
+ ** Copyright 2003-2026 The Supermodel Team
+ **
+ ** This file is part of Supermodel.
+ **
+ ** Supermodel is free software: you can redistribute it and/or modify it under
+ ** the terms of the GNU General Public License as published by the Free
+ ** Software Foundation, either version 3 of the License, or (at your option)
+ ** any later version.
+ **
+ ** Supermodel is distributed in the hope that it will be useful, but WITHOUT
+ ** ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ ** FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ ** more details.
+ **
+ ** You should have received a copy of the GNU General Public License along
+ ** with Supermodel.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+
 #include "R3DScrollFog.h"
 #include "Graphics/Shader.h"
 
@@ -79,9 +100,8 @@ void main()
 )glsl";
 
 
-	R3DScrollFog::R3DScrollFog(const Util::Config::Node& config)
-		: m_config(config),
-		m_vao(0)
+	R3DScrollFog::R3DScrollFog()
+		: m_vao(0)
 	{
 		m_shaderProgram		= 0;
 		m_vertexShader		= 0;
@@ -130,7 +150,7 @@ void main()
 
 	void R3DScrollFog::AllocResources()
 	{
-		auto success = LoadShaderProgram(&m_shaderProgram, &m_vertexShader, &m_fragmentShader, "", "", vertexShaderFog, fragmentShaderFog);
+		LoadShaderProgram(&m_shaderProgram, &m_vertexShader, &m_fragmentShader, "", "", vertexShaderFog, fragmentShaderFog);
 
 		m_locFogColour		= glGetUniformLocation(m_shaderProgram, "fogColour");
 		m_locFogAttenuation	= glGetUniformLocation(m_shaderProgram, "fogAttenuation");

--- a/Src/Graphics/New3D/R3DScrollFog.h
+++ b/Src/Graphics/New3D/R3DScrollFog.h
@@ -1,7 +1,27 @@
+/**
+ ** Supermodel
+ ** A Sega Model 3 Arcade Emulator.
+ ** Copyright 2003-2026 The Supermodel Team
+ **
+ ** This file is part of Supermodel.
+ **
+ ** Supermodel is free software: you can redistribute it and/or modify it under
+ ** the terms of the GNU General Public License as published by the Free
+ ** Software Foundation, either version 3 of the License, or (at your option)
+ ** any later version.
+ **
+ ** Supermodel is distributed in the hope that it will be useful, but WITHOUT
+ ** ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ ** FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ ** more details.
+ **
+ ** You should have received a copy of the GNU General Public License along
+ ** with Supermodel.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+
 #ifndef _R3DSCROLLFOG_H_
 #define _R3DSCROLLFOG_H_
 
-#include "Util/NewConfig.h"
 #include <GL/glew.h>
 
 namespace New3D {
@@ -10,7 +30,7 @@ namespace New3D {
 	{
 	public:
 
-		R3DScrollFog(const Util::Config::Node& config);
+		R3DScrollFog();
 		~R3DScrollFog();
 
 		void DrawScrollFog(float rbga[4], float attenuation, float ambient, float spotRGB[3], float spotEllipse[4]);
@@ -19,8 +39,6 @@ namespace New3D {
 
 		void AllocResources();
 		void DeallocResources();
-
-		const Util::Config::Node& m_config;
 
 		GLuint m_shaderProgram;
 		GLuint m_vertexShader;

--- a/Src/Inputs/Input.cpp
+++ b/Src/Inputs/Input.cpp
@@ -143,9 +143,8 @@ void CInput::AppendMapping(const char *mapping)
 	else
 	{
 		// Otherwise, append to mapping string and recreate source from new mapping string
-		size_t size = MAX_MAPPING_LENGTH - strlen(m_mapping);
-		strncat(m_mapping, ",", size--);
-		strncat(m_mapping, mapping, size);
+		size_t currentLen = strlen(m_mapping);
+		snprintf(m_mapping + currentLen, MAX_MAPPING_LENGTH + 1 - currentLen, ",%s", mapping);
 		CreateSource();
 	}
 }

--- a/Src/Inputs/Input.cpp
+++ b/Src/Inputs/Input.cpp
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **

--- a/Src/Inputs/Input.cpp
+++ b/Src/Inputs/Input.cpp
@@ -32,8 +32,8 @@
 #include "InputSystem.h"
 
 CInput::CInput(const char *inputId, const char *inputLabel, unsigned inputFlags, unsigned inputGameFlags, const char *defaultMapping, UINT16 initValue) : 
-	id(inputId), label(inputLabel), flags(inputFlags), gameFlags(inputGameFlags), m_defaultMapping(defaultMapping), value(initValue), prevValue(initValue),
-	m_system(NULL), m_source(NULL)
+	m_defaultMapping(defaultMapping), m_system(NULL), m_source(NULL),
+	id(inputId), label(inputLabel), flags(inputFlags), gameFlags(inputGameFlags), value(initValue), prevValue(initValue)
 {
 	ResetToDefaultMapping();
 }

--- a/Src/Model3/53C810.cpp
+++ b/Src/Model3/53C810.cpp
@@ -423,7 +423,7 @@ UINT32 C53C810::ReadPCIConfigSpace(unsigned device, unsigned reg, unsigned bits,
 {
   UINT32  d;
   
-  if ((bits==8))
+  if (bits == 8)
   {
     DebugLog("53C810 %d-bit PCI read request for reg=%02X\n", bits, reg);
     return 0;

--- a/Src/Model3/53C810.cpp
+++ b/Src/Model3/53C810.cpp
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson 
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **

--- a/Src/Model3/DSB.cpp
+++ b/Src/Model3/DSB.cpp
@@ -1,8 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011-2021 Bart Trzynadlowski, Nik Henson, Ian Curtis,
- **                     Harry Tuttle, and Spindizzi
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **
@@ -671,7 +670,7 @@ static constexpr const char *stateName[] =
 
 void CDSB2::WriteMPEGFIFO(UINT8 byte)
 {
-	//printf("fifo: %x (state %s)\n", byte, stateName[mpegState]);
+	DebugLog("fifo: %x (state %s)\n", byte, stateName[mpegState]);
 	switch (mpegState)
 	{
 		case ST_IDLE:

--- a/Src/Model3/JTAG.cpp
+++ b/Src/Model3/JTAG.cpp
@@ -102,6 +102,7 @@ void CASIC::CaptureDR()
     default:                    // BYPASS
         m_shiftRegSize = 1;
         m_shiftReg = 0;
+        break;
     }
 }
 
@@ -118,6 +119,8 @@ void CASIC::UpdateDR()
     case 8:                     // MODEWORD
         m_modeword = m_shiftReg.to_ulong();
         m_real3D.WriteJTAGModeword(m_deviceName, m_modeword);
+        break;
+    default:
         break;
     }
 }
@@ -162,6 +165,7 @@ void C3DRAM::CaptureDR()
     default:                // BYPASS
         m_shiftRegSize = 1;
         m_shiftReg = 0;
+        break;
     }
 }
 
@@ -282,6 +286,8 @@ void CJTAG::Write(bool tck, bool tms, bool tdi, bool trst)
             for (uint32_t i = 0; i < m_numDevices; i++)
                 tdi = m_device[i]->Shift(tdi);
             break;
+        default:
+            break;
         }
 
         // Go to next state
@@ -302,6 +308,8 @@ void CJTAG::Write(bool tck, bool tms, bool tdi, bool trst)
         case State::UpdateIR:
             for (uint32_t i = 0; i < m_numDevices; i++)
                 m_device[i]->UpdateIR();
+            break;
+        default:
             break;
         }
     }
@@ -361,6 +369,7 @@ void CJTAG::SetStepping(int stepping)
         m_mars01.SetIDCode(0x116c6057);
         m_jupiter.SetIDCode(0x116c7057);
         m_numDevices = 10;
+        break;
     }
 }
 

--- a/Src/Model3/Model3.cpp
+++ b/Src/Model3/Model3.cpp
@@ -3329,8 +3329,7 @@ CModel3::CModel3(Util::Config::Node &config)
 }
 
 // Dumps a memory region to a file for debugging purposes
-#if 0
-static void Dump(const char *file, uint8_t *buf, size_t size, bool reverse32, bool reverse16)
+static void Dump(const char *name, const char *file, uint8_t *buf, size_t size, bool reverse32, bool reverse16)
 {
   FILE *fp = fopen(file, "wb");
   if (NULL != fp)
@@ -3341,22 +3340,24 @@ static void Dump(const char *file, uint8_t *buf, size_t size, bool reverse32, bo
       Util::FlipEndian16(buf, size);
     fwrite(buf, sizeof(UINT8), size, fp);
     fclose(fp);
-    printf("dumped %s\n", file);
+    printf("Wrote %s to '%s'\n", name, file);
   }
   else
-    printf("unable to dump %s\n", file);
+    ErrorLog("Unable to open '%s' for writing.", file);
 }
-#endif
 
 CModel3::~CModel3(void)
 {
-  // Debug: dump some files
-  //Dump("ram", ram, 0x800000, true, false);
-  //Dump("vrom", vrom, 0x4000000, true, false);
-  //Dump("crom", crom, 0x800000, true, false);
-  //Dump("bankedCrom", &crom[0x800000], 0x7000000, true, false);
-  //Dump("soundROM", soundROM, 0x80000, false, true);
-  //Dump("sampleROM", sampleROM, 0x800000, false, true);
+  // Dump memory if requested
+  if (m_config["DumpMemory"].ValueAsDefault<bool>(false))
+  {
+    Dump("RAM", "ram.bin", ram, 0x800000, true, false);
+    Dump("VROM", "vrom.bin", vrom, 0x4000000, true, false);
+    Dump("CROM", "crom.bin", crom, 0x800000, true, false);
+    Dump("banked CROM", "banked_crom.bin", &crom[0x800000], 0x7000000, true, false);
+    Dump("sound ROM", "sound_rom.bin", soundROM, 0x80000, false, true);
+    Dump("sample ROM", "sample_rom.bin", sampleROM, 0x800000, false, true);
+  }
 
   // Stop all threads
   StopThreads();

--- a/Src/Model3/Model3.cpp
+++ b/Src/Model3/Model3.cpp
@@ -2162,7 +2162,7 @@ void CModel3::RunMainBoardFrame(void)
     auto pingPongFlipLine = TileGen.ReadRegister(0x08);
 
 	// Run the PowerPC for the active display part of the frame
-    for (int i = 0; i < 384; i++)
+    for (unsigned int i = 0; i < 384; i++)
     {
         if (i == pingPongFlipLine) {
             GPU.FlipPingPongBit();

--- a/Src/Model3/Real3D.cpp
+++ b/Src/Model3/Real3D.cpp
@@ -917,6 +917,8 @@ void CReal3D::WriteJTAGModeword(CASIC::Name device, uint32_t data)
     case CASIC::Name::Mars:
         Render3D->SetSunClamp((data & 0x40000) == 0);
         break;
+    default:
+        break;
     }
 }
 
@@ -979,7 +981,7 @@ uint32_t CReal3D::ReadPCIConfigSpace(unsigned device, unsigned reg, unsigned bit
 {
   uint32_t  d;
 
-  if ((bits==8))
+  if (bits == 8)
   {
     DebugLog("Real3D: %d-bit PCI read request for reg=%02X\n", bits, reg);
     return 0;
@@ -1139,48 +1141,7 @@ Result CReal3D::Init(const uint8_t *vromPtr, IBus *BusObjectPtr, CIRQ *IRQObject
 
 CReal3D::CReal3D(const Util::Config::Node &config)
   : m_config(config),
-    m_gpuMultiThreaded(config["GPUMultiThreaded"].ValueAs<bool>()),
-    Bus(nullptr),
-    IRQ(nullptr),
-    commandPortWritten(false),
-    cullingRAMHi(nullptr),
-    cullingRAMHiDirty(nullptr),
-    cullingRAMHiRO(nullptr),
-    dmaConfig(0),
-    dmaData(0),
-    dmaDest(0),
-    dmaIRQ(0),
-    dmaLength(0),
-    dmaSrc(0),
-    dmaStatus(0),
-    dmaUnknownReg(0),
-    m_modeword{},
-    m_pingPong(0),
-    pciID(0),
-    polyRAMDirty(nullptr),
-    polyRAMRO(nullptr),
-    step(0),
-    textureRAMDirty(nullptr),
-    textureRAMRO(nullptr),
-    m_polyUpdateBlock(nullptr),
-    m_highRamUpdateBlock(nullptr),
-    Render3D(nullptr),
-    memoryPool(nullptr),
-    cullingRAMLo(nullptr),
-    cullingRAMLoRO(nullptr),
-    cullingRAMLoDirty(nullptr),
-    polyRAM(nullptr),
-    textureRAM(nullptr),
-    textureFIFO(nullptr),
-    vrom(nullptr),
-    error(false),
-    fifoIdx(0),
-    m_vromTextureFIFO{},
-    m_vromTextureFIFOIdx(0),
-    m_internalRenderConfig{},
-    m_configRegisters{},
-    m_tilegenDrawFrame(false),
-    m_blockCullingRO(false)
+    m_gpuMultiThreaded(config["GPUMultiThreaded"].ValueAs<bool>())
 {
   DebugLog("Built Real3D\n");
 }

--- a/Src/Model3/Real3D.cpp
+++ b/Src/Model3/Real3D.cpp
@@ -53,6 +53,7 @@
 #include "JTAG.h"
 #include "CPU/PowerPC/ppc.h"
 #include "Util/BMPFile.h"
+#include "Util/BitCast.h"
 #include <cstring>
 #include <algorithm>
 
@@ -167,11 +168,11 @@ void CReal3D::LoadState(CBlockFile *SaveState)
   SaveState->Read(&highCullUpdateBlockOffset, sizeof(highCullUpdateBlockOffset));
 
   // use -1 to indicate null pointer
-  if (polyUpdateBlockOffset==-1) { m_polyUpdateBlock = nullptr;}
-  else                           { m_polyUpdateBlock = (UpdateBlock*)(cullingRAMLo + m_configRegisters.pingPongMemSize + polyUpdateBlockOffset); }
+  if (polyUpdateBlockOffset == (uint32_t)-1) { m_polyUpdateBlock = nullptr;}
+  else                                       { m_polyUpdateBlock = (UpdateBlock*)(cullingRAMLo + m_configRegisters.pingPongMemSize + polyUpdateBlockOffset); }
 
-  if (highCullUpdateBlockOffset == -1) { m_highRamUpdateBlock = nullptr; }
-  else                                 { m_highRamUpdateBlock = (UpdateBlock*)(cullingRAMLo + highCullUpdateBlockOffset); }
+  if (highCullUpdateBlockOffset == (uint32_t)-1) { m_highRamUpdateBlock = nullptr; }
+  else                                           { m_highRamUpdateBlock = (UpdateBlock*)(cullingRAMLo + highCullUpdateBlockOffset); }
   
 }
 
@@ -969,7 +970,7 @@ uint32_t CReal3D::ReadRegister(unsigned reg)
 
 	int index = (reg - 20) / 4;
 	float val = Render3D->GetLosValue(index);
-	return *(uint32_t*)(&val);
+	return Util::FloatAsUint32(val);
   }
 
   return 0xffffffff;

--- a/Src/Model3/Real3D.h
+++ b/Src/Model3/Real3D.h
@@ -474,26 +474,26 @@ private:
   const bool                m_gpuMultiThreaded;
 
   // Renderer attached to the Real3D
-  IRender3D *Render3D;
+  IRender3D *Render3D = nullptr;
   
   // Data passed from Model 3 object
-  const uint32_t  *vrom;  // Video ROM
-  int             step;   // hardware stepping (as in GameInfo structure)
-  uint32_t        pciID;  // PCI vendor and device ID
+  const uint32_t  *vrom = nullptr;          // Video ROM
+  int             step = 0x10;              // hardware stepping (as in GameInfo structure)
+  uint32_t        pciID = PCIID::Step1x;;   // PCI vendor and device ID
   
   // Error flag (to limit errors to once per frame)
-  bool error; // true if an error occurred this frame
+  bool error = false;   // true if an error occurred this frame
 
   // Real3D memory
-  uint8_t   *memoryPool;        // all memory allocated here
-  uint32_t  *cullingRAMLo;      // 4MB of culling RAM at 8C000000
-  uint32_t  *cullingRAMHi;      // 1MB of culling RAM at 8E000000
-  uint32_t  *polyRAM;           // 4MB of polygon RAM at 98000000
-  uint16_t  *textureRAM;        // 8MB of internal texture RAM
-  uint32_t  *textureFIFO;       // 1MB texture FIFO at 0x94000000
-  uint32_t  fifoIdx;            // index into texture FIFO
-  uint32_t  m_vromTextureFIFO[2];
-  uint32_t  m_vromTextureFIFOIdx;
+  uint8_t   *memoryPool = nullptr;      // all memory allocated here
+  uint32_t  *cullingRAMLo = nullptr;    // 4MB of culling RAM at 8C000000
+  uint32_t  *cullingRAMHi = nullptr;    // 1MB of culling RAM at 8E000000
+  uint32_t  *polyRAM = nullptr;         // 4MB of polygon RAM at 98000000
+  uint16_t  *textureRAM = nullptr;      // 8MB of internal texture RAM
+    uint32_t  *textureFIFO = nullptr;   // 1MB texture FIFO at 0x94000000
+  uint32_t  fifoIdx = 0;                // index into texture FIFO
+  uint32_t  m_vromTextureFIFO[2] = { 0,  0 };
+  uint32_t  m_vromTextureFIFOIdx = 0;
 
   union ConfigRegisters {
       uint32_t regs[4];
@@ -507,54 +507,53 @@ private:
 
   
   // Read-only snapshots
-  uint32_t  *cullingRAMLoRO;    // 4MB of culling RAM at 8C000000 [read-only snapshot]
-  uint32_t  *cullingRAMHiRO;    // 1MB of culling RAM at 8E000000 [read-only snapshot]
-  uint32_t  *polyRAMRO;         // 4MB of polygon RAM at 98000000 [read-only snapshot]
-  uint16_t  *textureRAMRO;      // 8MB of internal texture RAM    [read-only snapshot]
+  uint32_t  *cullingRAMLoRO = nullptr;  // 4MB of culling RAM at 8C000000 [read-only snapshot]
+  uint32_t  *cullingRAMHiRO = nullptr;  // 1MB of culling RAM at 8E000000 [read-only snapshot]
+  uint32_t  *polyRAMRO = nullptr;       // 4MB of polygon RAM at 98000000 [read-only snapshot]
+  uint16_t  *textureRAMRO = nullptr;    // 8MB of internal texture RAM    [read-only snapshot]
   
   // Arrays to keep track of dirty pages in memory regions
-  uint8_t   *cullingRAMLoDirty;
-  uint8_t   *cullingRAMHiDirty;
-  uint8_t   *polyRAMDirty;
-  uint8_t   *textureRAMDirty;
+  uint8_t   *cullingRAMLoDirty = nullptr;
+  uint8_t   *cullingRAMHiDirty = nullptr;
+  uint8_t   *polyRAMDirty = nullptr;
+  uint8_t   *textureRAMDirty = nullptr;
 
   // Queued texture uploads
   std::vector<QueuedUploadTextures> queuedUploadTextures;
   std::vector<QueuedUploadTextures> queuedUploadTexturesRO;  // Read-only copy of queue
   
   // Big endian bus object for DMA memory access
-  IBus  *Bus;
+  IBus  *Bus = nullptr;
   
   // IRQ handling
-  CIRQ    *IRQ;   // IRQ controller
-  uint32_t  dmaIRQ; // IRQ bit to use when calling IRQ handler
+  CIRQ    *IRQ = nullptr;   // IRQ controller
+  uint32_t  dmaIRQ = 0;     // IRQ bit to use when calling IRQ handler
   
   // DMA device
-  uint32_t  dmaSrc;
-  uint32_t  dmaDest;
-  uint32_t  dmaLength;
-  uint32_t  dmaData;
-  uint32_t  dmaUnknownReg;
-  uint8_t   dmaStatus;
-  uint8_t   dmaConfig;
+  uint32_t  dmaSrc = 0;
+  uint32_t  dmaDest = 0;
+  uint32_t  dmaLength = 0;
+  uint32_t  dmaData = 0;
+  uint32_t  dmaUnknownReg = 0;
+  uint8_t   dmaStatus = 0;
+  uint8_t   dmaConfig = 0;
   
   // Command port
-  bool  commandPortWritten;
-  bool  m_tilegenDrawFrame;
+  bool  commandPortWritten = false;
+  bool  m_tilegenDrawFrame = false;
   
   // Status and command registers
-  uint32_t m_pingPong;
-  uint32_t m_pingPongCopy;      // we copy the value during v-blank to see if ping_pong has flipped during the frame
-  bool m_blockCullingRO;        // really just disables rendering
+  uint32_t m_pingPong = 0;
+  uint32_t m_pingPongCopy = 0;      // we copy the value during v-blank to see if ping_pong has flipped during the frame
+  bool m_blockCullingRO = false;    // really just disables rendering
 
   // Internal ASIC state
-  uint64_t m_internalRenderConfig[2];
-  uint32_t m_modeword[5];
+  uint64_t m_internalRenderConfig[2] = { 0, 0 };
+  uint32_t m_modeword[5] = { 0, 0, 0, 0, 0 };
 
   // pointers to our buffered memory
-  UpdateBlock* m_polyUpdateBlock;
-  UpdateBlock* m_highRamUpdateBlock;
-
+  UpdateBlock* m_polyUpdateBlock = nullptr;
+  UpdateBlock* m_highRamUpdateBlock = nullptr;
 };
 
 

--- a/Src/OSD/Logger.cpp
+++ b/Src/OSD/Logger.cpp
@@ -1,8 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011-2020 Bart Trzynadlowski, Nik Henson, Ian Curtis,
- **                     Harry Tuttle, and Spindizzi
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **
@@ -353,7 +352,7 @@ void CSystemLogger::DebugLog(const char *fmt, va_list vl)
 #ifdef _WIN32
   OutputDebugString(string2);
 #else
-  syslog(LOG_DEBUG, string2);
+  syslog(LOG_DEBUG, "%s", string2);
 #endif
 }
 
@@ -373,7 +372,7 @@ void CSystemLogger::InfoLog(const char *fmt, va_list vl)
 #ifdef _WIN32
   OutputDebugString(string2);
 #else
-  syslog(LOG_INFO, string2);
+  syslog(LOG_INFO, "%s", string2);
 #endif
 }
 
@@ -393,7 +392,7 @@ void CSystemLogger::ErrorLog(const char *fmt, va_list vl)
 #ifdef _WIN32
   OutputDebugString(string2);
 #else
-  syslog(LOG_ERR, string2);
+  syslog(LOG_ERR, "%s", string2);
 #endif
 }
 

--- a/Src/OSD/SDL/Audio.cpp
+++ b/Src/OSD/SDL/Audio.cpp
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **
@@ -295,6 +295,8 @@ static void MixChannels(unsigned numSamples, const float* leftFrontBuffer, const
         case Game::QUAD_1_RRL_2_FRL:
             flipStereo = !flipStereo;
             break;
+        default: // all other types are left-before-right ordered and need no flip
+            break;
         }
 
         // Now order channels according to audio type
@@ -442,6 +444,8 @@ Result OpenAudio(const Util::Config::Node& config)
     case Game::STEREO_LR:
     case Game::STEREO_RL:
         nbHostAudioChannels = std::min(nbHostAudioChannels, 2);
+        break;
+    default: // quad types need up to 4 channels; config value already defaults to 4
         break;
     }
     // Mixer Balance
@@ -639,7 +643,7 @@ bool OutputAudio(unsigned numSamples, const float* leftFrontBuffer, const float*
         dst1 = audioBuffer + writePos;
         dst2 = NULL;
         len1 = numBytes;
-        len2 = NULL;
+        len2 = 0;
     }
 
     // Copy chunk to write position in buffer

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1584,6 +1584,7 @@ Util::Config::Node DefaultConfig()
   config.Set("SDLConstForceThreshold", 30, "ForceFeedback", 0, 100);
 #endif
   config.Set<std::string>("Outputs", "none", "Misc", "", "", { "none","win" });
+  config.Set("DumpMemory", false, "Misc");
   config.Set("DumpTextures", false, "Misc");
 
   //
@@ -1891,6 +1892,7 @@ static void Help(void)
   puts("  -print-inputs           Prints current input configuration");
   puts("");
   puts("Debug Options:");
+  puts("  -dump-memory            Write memory regions to files on exit");
   puts("  -dump-textures          Write textures to bitmap image files on exit");
 #ifdef SUPERMODEL_DEBUGGER
   puts("  -disable-debugger       Completely disable debugger functionality");
@@ -1995,6 +1997,7 @@ static ParsedCommandLine ParseCommandLine(int argc, char **argv)
 #endif
     { "-no-force-feedback",   { "ForceFeedback",    false } },
     { "-force-feedback",      { "ForceFeedback",    true } },
+    { "-dump-memory",         { "DumpMemory",       true } },
     { "-dump-textures",       { "DumpTextures",     true } },
   };
   for (int i = 1; i < argc; i++)

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -237,7 +237,7 @@ static void SetFullScreenRefreshRate()
                 return;
             }
 
-            if (SDL_BITSPERPIXEL(mode.format) >= 24 && mode.w == totalXRes && mode.h == totalYRes) {
+            if (SDL_BITSPERPIXEL(mode.format) >= 24 && (unsigned)mode.w == totalXRes && (unsigned)mode.h == totalYRes) {
                 if (mode.refresh_rate == 57 || mode.refresh_rate == 58) {       // nvidia is fairly flexible in what refresh rate windows will show, so we can match either 57 or 58,
                     int result = SDL_SetWindowDisplayMode(s_window, &mode);     // both are totally non standard frequencies and shouldn't be set incorrectly
                     if (result == 0) {

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2003-2025 The Supermodel Team
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -207,10 +207,10 @@ static Result SetGLGeometry(unsigned *xOffsetPtr, unsigned *yOffsetPtr, unsigned
   return Result::OKAY;
 }
 
-static void GLAPIENTRY DebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam)
-{
-    printf("OGLDebug:: 0x%X: %s\n", id, message);
-}
+// static void GLAPIENTRY DebugCallback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam)
+// {
+//     printf("OGLDebug:: 0x%X: %s\n", id, message);
+// }
 
 // In windows with an nvidia card (sorry not tested anything else) you can customise the resolution.
 // This also allows you to set a totally custom refresh rate. Apparently you can drive most monitors at

--- a/Src/OSD/SDL/SDLInputSystem.cpp
+++ b/Src/OSD/SDL/SDLInputSystem.cpp
@@ -468,7 +468,7 @@ bool CSDLInputSystem::InitializeSystem()
 
 int CSDLInputSystem::GetKeyIndex(const char *keyName)
 {
-  for (int i = 0; i < NUM_SDL_KEYS; i++)
+  for (size_t i = 0; i < NUM_SDL_KEYS; i++)
   {
     if (stricmp(keyName, s_keyMap[i].keyName) == 0)
       return i;
@@ -478,7 +478,7 @@ int CSDLInputSystem::GetKeyIndex(const char *keyName)
 
 const char *CSDLInputSystem::GetKeyName(int keyIndex)
 {
-  if (keyIndex < 0 || keyIndex >= NUM_SDL_KEYS)
+  if (keyIndex < 0 || keyIndex >= (int)NUM_SDL_KEYS)
     return nullptr;
   return s_keyMap[keyIndex].keyName;
 }

--- a/Src/OSD/Windows/DirectInputSystem.cpp
+++ b/Src/OSD/Windows/DirectInputSystem.cpp
@@ -400,10 +400,7 @@ static BOOL CALLBACK DI8EnumObjectsCallback(LPCDIDEVICEOBJECTINSTANCE instance, 
 
 	// Get axis name from DirectInput and store that too
 	char *axisName = joyDetails->axisName[axisNum];
-	strcpy(axisName, CInputSystem::GetDefaultAxisName(axisNum));
-	strcat(axisName, " (");
-	strncat(axisName, instance->tszName, MAX_NAME_LENGTH - strlen(axisName) - 1);
-	strcat(axisName, ")");
+	snprintf(axisName, MAX_NAME_LENGTH + 1, "%s (%s)", CInputSystem::GetDefaultAxisName(axisNum), instance->tszName);
 
 	return DIENUM_CONTINUE;
 }
@@ -618,7 +615,7 @@ void CDirectInputSystem::OpenKeyboardsAndMice()
 						continue;
 					nLength = std::min<int>(MAX_NAME_LENGTH, nLength);
 					char name[MAX_NAME_LENGTH] = {};
-					if (m_getRIDevInfoPtr(device.hDevice, RIDI_DEVICENAME, name, &nLength) == -1)
+					if (m_getRIDevInfoPtr(device.hDevice, RIDI_DEVICENAME, name, &nLength) == (UINT)-1)
 						continue;
 
 					// Ignore any RDP devices
@@ -1629,7 +1626,7 @@ bool CDirectInputSystem::InitializeSystem()
 
 int CDirectInputSystem::GetKeyIndex(const char *keyName)
 {
-	for (int i = 0; i < NUM_DI_KEYS; i++)
+	for (size_t i = 0; i < NUM_DI_KEYS; i++)
 	{
 		if (stricmp(keyName, s_keyMap[i].keyName) == 0)
 			return i;
@@ -1639,7 +1636,7 @@ int CDirectInputSystem::GetKeyIndex(const char *keyName)
 
 const char *CDirectInputSystem::GetKeyName(int keyIndex)
 {
-	if (keyIndex < 0 || keyIndex >= NUM_DI_KEYS)
+	if (keyIndex < 0 || keyIndex >= (int)NUM_DI_KEYS)
 		return NULL;
 	return s_keyMap[keyIndex].keyName;
 }

--- a/Src/OSD/Windows/DirectInputSystem.h
+++ b/Src/OSD/Windows/DirectInputSystem.h
@@ -95,10 +95,10 @@ struct DIJoyInfo
 };
 
 // RawInput API
-typedef /*WINUSERAPI*/ INT (WINAPI *GetRawInputDeviceListPtr)(OUT PRAWINPUTDEVICELIST pRawInputDeviceList, IN OUT PUINT puiNumDevices, IN UINT cbSize);
-typedef /*WINUSERAPI*/ INT (WINAPI *GetRawInputDeviceInfoPtr)(IN HANDLE hDevice, IN UINT uiCommand, OUT LPVOID pData, IN OUT PUINT pcbSize);
+typedef /*WINUSERAPI*/ UINT (WINAPI *GetRawInputDeviceListPtr)(OUT PRAWINPUTDEVICELIST pRawInputDeviceList, IN OUT PUINT puiNumDevices, IN UINT cbSize);
+typedef /*WINUSERAPI*/ UINT (WINAPI *GetRawInputDeviceInfoPtr)(IN HANDLE hDevice, IN UINT uiCommand, OUT LPVOID pData, IN OUT PUINT pcbSize);
 typedef /*WINUSERAPI*/ bool (WINAPI *RegisterRawInputDevicesPtr)(IN PCRAWINPUTDEVICE pRawInputDevices, IN UINT uiNumDevices, IN UINT cbSize);
-typedef /*WINUSERAPI*/ INT (WINAPI *GetRawInputDataPtr)(IN HRAWINPUT hRawInput, IN UINT uiCommand, OUT LPVOID pData, IN OUT PUINT pcbSize, IN UINT cbSizeHeader);
+typedef /*WINUSERAPI*/ UINT (WINAPI *GetRawInputDataPtr)(IN HRAWINPUT hRawInput, IN UINT uiCommand, OUT LPVOID pData, IN OUT PUINT pcbSize, IN UINT cbSizeHeader);
 
 // XInput API
 typedef /*WINUSERAPI*/ DWORD (WINAPI *XInputGetCapabilitiesPtr)(IN DWORD dwUserIndex, IN DWORD dwFlags, OUT PXINPUT_CAPABILITIES pCapabilities);

--- a/Src/Sound/SCSP.cpp
+++ b/Src/Sound/SCSP.cpp
@@ -2,7 +2,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **
@@ -849,9 +849,6 @@ void SCSP_UpdateReg(int reg)
 		case 0x15:
 		case 0x16:
 		case 0x17:
-			{
-				int a=1;
-			}
 			break;
 		case 0x18:
 		case 0x19:
@@ -1035,13 +1032,10 @@ void SCSP_w8(unsigned int addr,unsigned char val)
 				((unsigned char *)SCSP->DSP.MADRS)[(addr - 0x780) ^ 1] = val;
 			else if (addr >= 0x800 && addr < 0xC00)
 				((unsigned char *)SCSP->DSP.MPRO)[(addr - 0x800) ^ 1] = val;
-			else
-				int a = 1;
 			if (addr == 0xBF0)
 			{
 				SCSPDSP_Start(&SCSP->DSP);
 			}
-			int a = 1;
 #endif
 		}
 		else {
@@ -1055,13 +1049,10 @@ void SCSP_w8(unsigned int addr,unsigned char val)
 				((unsigned char *)SCSP->DSP.MADRS)[(addr - 0x7c0) ^ 1] = val;
 			else if (addr < 0xC00)
 				((unsigned char *)SCSP->DSP.MPRO)[(addr - 0x800) ^ 1] = val;
-			else
-				int a = 1;
 			if (addr == 0xBF0)
 			{
 				SCSPDSP_Start(&SCSP->DSP);
 			}
-			int a = 1;
 #endif
 		}
 	}
@@ -1102,11 +1093,8 @@ void SCSP_w16(unsigned int addr,unsigned short val)
 				*(unsigned short *) &(SCSP->DSP.MADRS[(addr - 0x780) / 2]) = val;
 			else if (addr < 0xC00)
 				*(unsigned short *) &(SCSP->DSP.MPRO[(addr - 0x800) / 2]) = val;
-			else
-				int a = 1;
 			if (addr == 0xBF0)
 				SCSPDSP_Start(&SCSP->DSP);
-			int a = 1;
 #endif
 		}
 		else {
@@ -1122,11 +1110,8 @@ void SCSP_w16(unsigned int addr,unsigned short val)
 			{
 				*((UINT16 *)(SCSP->DSP.MPRO + (addr - 0x800) / 2)) = val;
 			}
-			else
-				int a = 1;
 			if (addr == 0xBF0)
 				SCSPDSP_Start(&SCSP->DSP);
-			int a = 1;
 #endif
 		}
 	}
@@ -1156,7 +1141,7 @@ void SCSP_w32(unsigned int addr,unsigned int val)
 		SCSP_UpdateReg((addr&0xff)+2);
 	}
 	else if(addr<0x700)
-		int a=1;
+		{} // do nothing
 	else
 	{
 #ifdef USEDSP
@@ -1170,11 +1155,8 @@ void SCSP_w32(unsigned int addr,unsigned int val)
 				*(unsigned int *) &(SCSP->DSP.MADRS[(addr-0x7c0)/2]) = val;
 			else if(addr<0xC00)
 				*(unsigned int *) &(SCSP->DSP.MPRO[(addr-0x800)/2])=val;
-			else
-				int a=1;
 			if(addr==0xBF0)
 				SCSPDSP_Start(&SCSP->DSP);
-			int a=1;
 #endif
 	}
 }

--- a/Src/Sound/SCSP.cpp
+++ b/Src/Sound/SCSP.cpp
@@ -1148,13 +1148,25 @@ void SCSP_w32(unsigned int addr,unsigned int val)
 		//DSP
 		rotl(val, 16);
 			if(addr<0x780)	//COEF
-				*(unsigned int *) &(SCSP->DSP.COEF[(addr-0x700)/2])=val;
+			{
+				SCSP->DSP.COEF[(addr-0x700)/2]     = (INT16)(val & 0xFFFF);
+				SCSP->DSP.COEF[(addr-0x700)/2 + 1] = (INT16)(val >> 16);
+			}
 			else if (addr < 0x7c0)
-				*(unsigned int *) &(SCSP->DSP.MADRS[(addr-0x780)/2]) = val;
+			{
+				SCSP->DSP.MADRS[(addr-0x780)/2]     = (UINT16)(val & 0xFFFF);
+				SCSP->DSP.MADRS[(addr-0x780)/2 + 1] = (UINT16)(val >> 16);
+			}
 			else if (addr < 0x800) // MADRS is mirrored twice
-				*(unsigned int *) &(SCSP->DSP.MADRS[(addr-0x7c0)/2]) = val;
+			{
+				SCSP->DSP.MADRS[(addr-0x7c0)/2]     = (UINT16)(val & 0xFFFF);
+				SCSP->DSP.MADRS[(addr-0x7c0)/2 + 1] = (UINT16)(val >> 16);
+			}
 			else if(addr<0xC00)
-				*(unsigned int *) &(SCSP->DSP.MPRO[(addr-0x800)/2])=val;
+			{
+				SCSP->DSP.MPRO[(addr-0x800)/2]     = (UINT16)(val & 0xFFFF);
+				SCSP->DSP.MPRO[(addr-0x800)/2 + 1] = (UINT16)(val >> 16);
+			}
 			if(addr==0xBF0)
 				SCSPDSP_Start(&SCSP->DSP);
 #endif

--- a/Src/Sound/SCSPDSP.cpp
+++ b/Src/Sound/SCSPDSP.cpp
@@ -1,7 +1,7 @@
 /**
  ** Supermodel
  ** A Sega Model 3 Arcade Emulator.
- ** Copyright 2011 Bart Trzynadlowski, Nik Henson
+ ** Copyright 2003-2026 The Supermodel Team
  **
  ** This file is part of Supermodel.
  **
@@ -36,7 +36,9 @@
 #include <cstdlib>
 #include <cstring>
 
+#ifdef _MSC_VER
 #pragma warning(disable:4311)
+#endif
 
 #define DYNBUF	0x10000
 

--- a/Src/Util/BitCast.h
+++ b/Src/Util/BitCast.h
@@ -8,6 +8,7 @@
 namespace Util
 {
 #define FloatAsInt32(x) std::bit_cast<int32_t>(x)
+#define FloatAsUint32(x) std::bit_cast<uint32_t>(x)
 #define Int32AsFloat(x) std::bit_cast<float>(x)
 #define Uint32AsFloat(x) std::bit_cast<float>(x)
 #else
@@ -26,6 +27,7 @@ inline Dest bit_cast(Source const& source) {
    return dest;
 }
 #define FloatAsInt32(x) bit_cast<int32_t,float>(x)
+#define FloatAsUint32(x) bit_cast<uint32_t,float>(x)
 #define Int32AsFloat(x) bit_cast<float,int32_t>(x)
 #define Uint32AsFloat(x) bit_cast<float,uint32_t>(x)
 #endif


### PR DESCRIPTION
Various fixes to eliminate warnings when using gcc on Windows and clang on macOS. In a couple of cases, warnings are explicitly suppressed for specific files altogether.

For all modified files, copyright headers were updated (or added when missing).

Also added a -dump-memory option to dump all memory regions (similar to -dump-textures) rather than having that functionality sitting around commented out in Model3.cpp.