### PR TITLE
Make shifter behavior work better with shifter controllers

### DIFF
--- a/Src/Inputs/InputTypes.cpp
+++ b/Src/Inputs/InputTypes.cpp
@@ -164,8 +164,8 @@ void CGearShift4Input::Poll()
 	prevValue = value;
 
 	// Gears (values 1-4) are set by pressing a button (lower gears have priority) and "stick" until a shift to another gear is made.
-	// Neutral is selected by pressing the neutral gear button. It means all gears are released (value 0).
-	if		(m_shiftNInput->Pressed()) value = 0;
+	// Neutral is selected by releasing all gear inputs (value 0).
+	if		(m_shift1Input->Released() || m_shift2Input->Released() || m_shift3Input->Released() || m_shift4Input->Released()) value = 0;
 	else if (m_shift1Input->Pressed()) value = 1;
 	else if (m_shift2Input->Pressed()) value = 2;
 	else if (m_shift3Input->Pressed()) value = 3;

--- a/Src/Inputs/InputTypes.cpp
+++ b/Src/Inputs/InputTypes.cpp
@@ -155,8 +155,8 @@ CGearShift4Input::CGearShift4Input(const char *inputId, const char *inputLabel, 
 		m_shift1Input(shift1Input), m_shift2Input(shift2Input), m_shift3Input(shift3Input), m_shift4Input(shift4Input), m_shiftNInput(shiftNInput),
 		m_shiftUpInput(shiftUpInput), m_shiftDownInput(shiftDownInput)
 {
-	// Initialize to gear 1
-	prevValue = value = 1;
+	// Initialize to gear 0
+	prevValue = value = 0;
 }
 
 void CGearShift4Input::Poll()

--- a/Src/Inputs/InputTypes.cpp
+++ b/Src/Inputs/InputTypes.cpp
@@ -163,7 +163,7 @@ void CGearShift4Input::Poll()
 {
 	prevValue = value;
 
-	// Gears (values 1-4) are set by pressing a button (lower gears have priority) and "stick" until a shift to another gear is made.
+	// Gears (values 1-4) are set by holding a button (lower gears have priority).
 	// Neutral is selected by releasing all gear inputs (value 0).
 	if		(m_shift1Input->Released() || m_shift2Input->Released() || m_shift3Input->Released() || m_shift4Input->Released()) value = 0;
 	else if (m_shift1Input->Pressed()) value = 1;


### PR DESCRIPTION
I have a Logitech G29 wheel with a shifter at home, and while the existing behavior makes the use of buttons for shifting more user-friendly, it doesn't exactly replicate the actual Sega shifter, which would be a better option with a shifter controller such as my Logitech one.
I do, however, understand that not everyone has a shifter controller at home, so maybe it would be better to implement a new variable that toggles between the original behavior and this one.