### PR TITLE
Lost World gun detection

### DIFF
--- a/Src/Model3/Model3.cpp
+++ b/Src/Model3/Model3.cpp
@@ -608,7 +608,7 @@ UINT8 CModel3::ReadInputs(unsigned reg)
   	  // probably to allow users to define inverted controls for this game only,
   	  // which means the input system must support loading per-game config (not
   	  // all analog_gun games require axis inversion to be playable).
-	  if (m_game.name == "lostwsga" || m_game.name == "lostwsgo")
+	  if (m_game.name == "lostwsga" || m_game.name == "lostwsgp")
 	  { // to do, not a string compare
         adc[0] =       (UINT8)Inputs->analogGunX[0]->value; // order is different for some reason in lost world
         adc[1] = 255 - (UINT8)Inputs->analogGunY[0]->value; // why are values inverted? is this the wrong place to fix this

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -979,7 +979,7 @@ int Supermodel(const Game &game, ROMSet *rom_set, IEmulator *Model3, CInputs *In
   // Hide mouse if fullscreen, enable crosshairs for gun games
   Inputs->GetInputSystem()->SetMouseVisibility(!s_runtime_config["FullScreen"].ValueAs<bool>());
   gameHasLightguns = !!(game.inputs & (Game::INPUT_GUN1|Game::INPUT_GUN2));
-  gameHasLightguns |= game.name == "lostwsga";
+  gameHasLightguns |= (game.name == "lostwsga" || game.name == "lostwsgp");
   currentInputs = game.inputs;
   if (gameHasLightguns)
     videoInputs = Inputs;


### PR DESCRIPTION
When Supermodel loads a merged ROM it ignores the parent.
This causes a problem with The Lost world child ROM as Supermodel isn't looking for/ recognising it.

Can't say I understand the GameLoader code but comments at line 718 onwards seem to explain the design choice,
https://github.com/trzy/Supermodel/blob/77d28eec84a5ededaa23bb31bc74db631cbe5530/Src/GameLoader.cpp#L718

BTW
This is also related to why people have been changing their games.xml from analog_gun1 to gun1 for the last seven years, as that trick bypasses this bug.

It also explains why people think they have a bad Lost World ROM, leading them to download a different ROM from another site. The ROMs often aren't bad, they are just merged.