### PR TITLE
Always use MPC105 for step 1.x and MPC106 for step 2.x

### DIFF
--- a/Config/Games.xml
+++ b/Config/Games.xml
@@ -19,7 +19,6 @@
     <hardware>
       <platform>Sega Model 3</platform>
       <stepping>1.0</stepping>
-      <pci_bridge>MPC106</pci_bridge>
       <inputs>
         <input type="common" />
         <input type="fishing" />
@@ -87,7 +86,6 @@
     <hardware>
       <platform>Sega Model 3</platform>
       <stepping>1.0</stepping>
-      <pci_bridge>MPC106</pci_bridge>
       <inputs>
         <input type="common" />
         <input type="fishing" />
@@ -113,7 +111,6 @@
     <hardware>
       <platform>Sega Model 3</platform>
       <stepping>1.0</stepping>
-      <pci_bridge>MPC106</pci_bridge>
       <inputs>
         <input type="common" />
         <input type="fishing" />
@@ -139,7 +136,6 @@
     <hardware>
       <platform>Sega Model 3</platform>
       <stepping>1.0</stepping>
-      <pci_bridge>MPC106</pci_bridge>
       <inputs>
         <input type="common" />
         <input type="fishing" />
@@ -346,7 +342,6 @@
       <stepping>2.1</stepping>
       <mpeg_board>DSB2</mpeg_board>
       <drive_board>Wheel</drive_board>
-      <real3d_pci_id>0x16C311DB</real3d_pci_id>
       <netboard>true</netboard>
       <inputs>
         <input type="common" />
@@ -420,7 +415,6 @@
       <stepping>2.1</stepping>
       <mpeg_board>DSB2</mpeg_board>
       <drive_board>Wheel</drive_board>
-      <real3d_pci_id>0x16C311DB</real3d_pci_id>
       <netboard>true</netboard>
       <inputs>
         <input type="common" />
@@ -452,7 +446,6 @@
       <stepping>2.1</stepping>
       <mpeg_board>DSB2</mpeg_board>
       <drive_board>Wheel</drive_board>
-      <real3d_pci_id>0x16C311DB</real3d_pci_id>
       <netboard>true</netboard>
       <inputs>
         <input type="common" />
@@ -484,7 +477,6 @@
       <stepping>2.1</stepping>
       <mpeg_board>DSB2</mpeg_board>
       <drive_board>Wheel</drive_board>
-      <real3d_pci_id>0x16C311DB</real3d_pci_id>
       <netboard>true</netboard>
       <inputs>
         <input type="common" />
@@ -516,7 +508,6 @@
       <stepping>2.1</stepping>
       <mpeg_board>DSB2</mpeg_board>
       <drive_board>Wheel</drive_board>
-      <real3d_pci_id>0x16C311DB</real3d_pci_id>
       <netboard>true</netboard>
       <inputs>
         <input type="common" />
@@ -954,7 +945,6 @@
     <hardware>
       <platform>Sega Model 3</platform>
       <stepping>2.1</stepping>
-      <real3d_pci_id>0x16C311DB</real3d_pci_id>
       <inputs>
         <input type="common" />
         <input type="analog_gun1" />
@@ -1221,7 +1211,6 @@
     <hardware>
       <platform>Sega Model 3</platform>
       <stepping>2.1</stepping>
-      <real3d_pci_id>0x16C311DB</real3d_pci_id>
       <inputs>
         <input type="common" />
         <input type="magtruck" />
@@ -1292,7 +1281,6 @@
     <hardware>
       <platform>Sega Model 3</platform>
       <stepping>2.1</stepping>
-      <real3d_pci_id>0x16C311DB</real3d_pci_id>
       <inputs>
         <input type="common" />
         <input type="magtruck" />
@@ -1738,7 +1726,6 @@
       <stepping>1.5</stepping>
       <mpeg_board>DSB1</mpeg_board>
       <drive_board>Wheel</drive_board>
-      <pci_bridge>MPC106</pci_bridge>
       <netboard>true</netboard>
       <audio>QuadFrontRear</audio>
       <inputs>
@@ -2614,7 +2601,6 @@
       <platform>Sega Model 3</platform>
       <stepping>2.0</stepping>
       <drive_board>Billboard</drive_board>
-      <real3d_pci_id>0x16C311DB</real3d_pci_id>
       <netboard>true</netboard>
       <inputs>
         <input type="common" />
@@ -2695,7 +2681,6 @@
       <platform>Sega Model 3</platform>
       <stepping>2.0</stepping>
       <drive_board>Billboard</drive_board>
-      <real3d_pci_id>0x16C311DB</real3d_pci_id>
       <netboard>true</netboard>
       <inputs>
         <input type="common" />
@@ -2724,7 +2709,6 @@
       <platform>Sega Model 3</platform>
       <stepping>2.0</stepping>
       <drive_board>Billboard</drive_board>
-      <real3d_pci_id>0x16C311DB</real3d_pci_id>
       <netboard>true</netboard>
       <inputs>
         <input type="common" />
@@ -2753,7 +2737,6 @@
       <platform>Sega Model 3</platform>
       <stepping>2.0</stepping>
       <drive_board>Billboard</drive_board>
-      <real3d_pci_id>0x16C311DB</real3d_pci_id>
       <netboard>true</netboard>
       <inputs>
         <input type="common" />
@@ -2860,7 +2843,6 @@
       <platform>Sega Model 3</platform>
       <stepping>1.5</stepping>
       <drive_board>Billboard</drive_board>
-      <pci_bridge>MPC106</pci_bridge>
       <inputs>
         <input type="common" />
         <input type="joystick1" />
@@ -2890,7 +2872,6 @@
       <platform>Sega Model 3</platform>
       <stepping>1.5</stepping>
       <drive_board>Billboard</drive_board>
-      <pci_bridge>MPC106</pci_bridge>
       <inputs>
         <input type="common" />
         <input type="joystick1" />
@@ -3010,7 +2991,6 @@
       <platform>Sega Model 3</platform>
       <stepping>1.5</stepping>
       <drive_board>Billboard</drive_board>
-      <pci_bridge>MPC106</pci_bridge>
       <inputs>
         <input type="common" />
         <input type="joystick1" />
@@ -3205,7 +3185,6 @@
       <platform>Sega Model 3</platform>
       <stepping>1.5</stepping>
       <drive_board>Billboard</drive_board>
-      <pci_bridge>MPC106</pci_bridge>
       <inputs>
         <input type="common" />
         <input type="joystick1" />
@@ -3233,7 +3212,6 @@
     <hardware>
       <platform>Sega Model 3</platform>
       <stepping>1.5</stepping>
-      <pci_bridge>MPC106</pci_bridge>
       <drive_board>Billboard</drive_board>
       <inputs>
         <input type="common" />
@@ -3262,7 +3240,6 @@
     <hardware>
       <platform>Sega Model 3</platform>
       <stepping>1.5</stepping>
-      <pci_bridge>MPC106</pci_bridge>
       <drive_board>Billboard</drive_board>
       <inputs>
         <input type="common" />

--- a/Src/Game.h
+++ b/Src/Game.h
@@ -27,8 +27,6 @@ struct Game
       QUAD_1_LR_2_FR_MIX,   // Specific srally2: Split SCSP2 and mix first channel to DSB+SCP11 Front Left/Right and second to Read Left/Right
   };
   AudioTypes audio = STEREO_LR;
-  std::string pci_bridge;               // overrides default PCI bridge type for stepping (empty string for default)
-  uint32_t real3d_pci_id = 0;           // overrides default Real3D PCI ID for stepping (0 for default)
   uint32_t encryption_key = 0;
   bool netboard_present = false;
 

--- a/Src/GameLoader.cpp
+++ b/Src/GameLoader.cpp
@@ -272,8 +272,6 @@ static void PopulateGameInfo(Game *game, const Util::Config::Node &game_node)
   };
   std::string audio_type = game_node["hardware/audio"].ValueAsDefault<std::string>("");
   game->audio = audio_types[audio_type];
-  game->pci_bridge = game_node["hardware/pci_bridge"].ValueAsDefault<std::string>("");
-  game->real3d_pci_id = game_node["hardware/real3d_pci_id"].ValueAsDefault<uint32_t>(0);
   game->encryption_key = game_node["hardware/encryption_key"].ValueAsDefault<uint32_t>(0);
   game->netboard_present = game_node["hardware/netboard"].ValueAsDefault<bool>(false);
 

--- a/Src/Model3/Model3.cpp
+++ b/Src/Model3/Model3.cpp
@@ -1098,7 +1098,9 @@ UINT16 CModel3::Read16(UINT32 addr)
 
     // MPC105
     case 0xC0:  // F0C00CF8
-      return PCIBridge.ReadPCIConfigData(16,addr&3);
+      if (PCIBridge.GetModel() == 0x105)
+        return PCIBridge.ReadPCIConfigData(16,addr&3);
+      break;
 
     // MPC106
     case 0xE0:
@@ -1117,7 +1119,9 @@ UINT16 CModel3::Read16(UINT32 addr)
     case 0xED:
     case 0xEE:
     case 0xEF:
-      return PCIBridge.ReadPCIConfigData(16,addr&3);
+      if (PCIBridge.GetModel() == 0x106)
+        return PCIBridge.ReadPCIConfigData(16,addr&3);
+      break;
 
     // Unknown
     default:
@@ -1233,7 +1237,9 @@ UINT32 CModel3::Read32(UINT32 addr)
 
     // MPC105
     case 0xC0:  // F0C00CF8
-      return PCIBridge.ReadPCIConfigData(32,0);
+      if (PCIBridge.GetModel() == 0x105)
+        return PCIBridge.ReadPCIConfigData(32,0);
+      break;
 
     // MPC106
     case 0xE0:
@@ -1252,7 +1258,9 @@ UINT32 CModel3::Read32(UINT32 addr)
     case 0xED:
     case 0xEE:
     case 0xEF:
-      return PCIBridge.ReadPCIConfigData(32,0);
+      if (PCIBridge.GetModel() == 0x105)
+        return PCIBridge.ReadPCIConfigData(32,0);
+      break;
 
     // RTC
     case 0x14:
@@ -1444,9 +1452,10 @@ void CModel3::Write8(UINT32 addr, UINT8 data)
     }
     goto Unknown8;
 
-  // MPC105/106
+  // MPC105
   case 0xF8:
-    PCIBridge.WriteRegister(addr&0xFF,data);
+    if (PCIBridge.GetModel() == 0x105)
+      PCIBridge.WriteRegister(addr&0xFF,data);
     break;
 
   // 53C810 SCSI
@@ -1535,7 +1544,8 @@ void CModel3::Write16(UINT32 addr, UINT16 data)
 
     // MPC105
     case 0xC0:  // F0C00CF8
-      PCIBridge.WritePCIConfigData(16,addr&2,data);
+      if (PCIBridge.GetModel() == 0x105)
+        PCIBridge.WritePCIConfigData(16,addr&2,data);
       break;
 
     // Unknown
@@ -1556,11 +1566,14 @@ void CModel3::Write16(UINT32 addr, UINT16 data)
     }
     goto Unknown16;
 
-  // MPC105/106
+  // MPC105
   case 0xF8:
-    // Write in big endian order, like a real PowerPC
-    PCIBridge.WriteRegister((addr&0xFF)+0,data>>8);
-    PCIBridge.WriteRegister((addr&0xFF)+1,data&0xFF);
+    if (PCIBridge.GetModel() == 0x105)
+    {
+      // Write in big endian order, like a real PowerPC
+      PCIBridge.WriteRegister((addr&0xFF)+0,data>>8);
+      PCIBridge.WriteRegister((addr&0xFF)+1,data&0xFF);
+    }
     break;
 
   case 0xC0: // skichamp only
@@ -1672,8 +1685,9 @@ void CModel3::Write32(UINT32 addr, UINT32 data)
       break;
 
     // MPC105
-    case 0x80:  // F0800CF8 (never observed at 0xFExxxxxx)
-      PCIBridge.WritePCIConfigAddress(data);
+    case 0x80:  // F0800CF8
+      if (PCIBridge.GetModel() == 0x105)
+        PCIBridge.WritePCIConfigAddress(data);
       break;
 
     // MPC105/106
@@ -1693,11 +1707,11 @@ void CModel3::Write32(UINT32 addr, UINT32 data)
     case 0xCD: case 0xDD: case 0xED:
     case 0xCE: case 0xDE: case 0xEE:
     case 0xCF: case 0xDF: case 0xEF:
-      if ((addr>=0xF0C00CF8) && (addr<0xF0C00D00))    // MPC105
+      if ((PCIBridge.GetModel() == 0x105) && (addr>=0xF0C00CF8) && (addr<0xF0C00D00))    // MPC105
         PCIBridge.WritePCIConfigData(32,0,data);
-      else if ((addr>=0xFEC00000) && (addr<0xFEE00000)) // MPC106
+      else if ((PCIBridge.GetModel() == 0x106) && (addr>=0xFEC00000) && (addr<0xFEE00000)) // MPC106
         PCIBridge.WritePCIConfigAddress(data);
-      else if ((addr>=0xFEE00000) && (addr<0xFEF00000)) // MPC106
+      else if ((PCIBridge.GetModel() == 0x106) && (addr>=0xFEE00000) && (addr<0xFEF00000)) // MPC106
         PCIBridge.WritePCIConfigData(32,0,data);
       break;
 
@@ -1754,13 +1768,16 @@ void CModel3::Write32(UINT32 addr, UINT32 data)
 
     goto Unknown32;
 
-  // MPC105/106
-  case 0xF8:  // F8FFF000-F8FFF100
-    // Write in big endian order, like a real PowerPC
-    PCIBridge.WriteRegister((addr&0xFF)+0,(data>>24)&0xFF);
-    PCIBridge.WriteRegister((addr&0xFF)+1,(data>>16)&0xFF);
-    PCIBridge.WriteRegister((addr&0xFF)+2,(data>>8)&0xFF);
-    PCIBridge.WriteRegister((addr&0xFF)+3,data&0xFF);
+  // MPC105
+  case 0xF8:  // F8FFF000-F8FFF0FF
+    if (PCIBridge.GetModel() == 0x105)
+    {
+      // Write in big endian order, like a real PowerPC
+      PCIBridge.WriteRegister((addr&0xFF)+0,(data>>24)&0xFF);
+      PCIBridge.WriteRegister((addr&0xFF)+1,(data>>16)&0xFF);
+      PCIBridge.WriteRegister((addr&0xFF)+2,(data>>8)&0xFF);
+      PCIBridge.WriteRegister((addr&0xFF)+3,data&0xFF);
+    }
     break;
 
   // 53C810 SCSI
@@ -2921,16 +2938,6 @@ Result CModel3::LoadGame(const Game &game, const ROMSet &rom_set)
   {
     ErrorLog("Cannot configure Model 3 because game uses unrecognized stepping (%s).", game.stepping.c_str());
     return Result::FAIL;
-  }
-
-  if (!game.pci_bridge.empty())
-  {
-    if (game.pci_bridge == "MPC105")
-      PCIBridge.SetModel(0x105);
-    else if (game.pci_bridge == "MPC106")
-      PCIBridge.SetModel(0x106);
-    else
-      ErrorLog("Unknown PCI bridge specified in ROM set definition file (%s). Defaulting to MPC%X.", game.pci_bridge.c_str(), PCIBridge.GetModel());
   }
 
   // Initialize CPU

--- a/Src/Model3/Model3.cpp
+++ b/Src/Model3/Model3.cpp
@@ -1258,7 +1258,7 @@ UINT32 CModel3::Read32(UINT32 addr)
     case 0xED:
     case 0xEE:
     case 0xEF:
-      if (PCIBridge.GetModel() == 0x105)
+      if (PCIBridge.GetModel() == 0x106)
         return PCIBridge.ReadPCIConfigData(32,0);
       break;
 


### PR DESCRIPTION
Some step 1.x games try to detect MPC106 first by accessing it via 0xFEC00CF8 and 0xFEE00CFC but then fail because the device ID is incorrect; we need to make sure MPC105 is only accessible via 0xF0800CF8 and 0xF0C00CFC

Remove <pci_bridge> and <real3d_pci_id> tags from Games.xml as they are no longer needed