### PR TITLE
[vs298] Update Games.xml

### DIFF
--- a/Config/Games.xml
+++ b/Config/Games.xml
@@ -2925,7 +2925,7 @@
         <file offset="0" name="epr-20920.20" crc32="0x428D05FC" />
         <file offset="2" name="epr-20919.19" crc32="0x7A0713D2" />
         <file offset="4" name="epr-20918.18" crc32="0x0E9CDC5B" />
-        <file offset="6" name="epr-20917.17" crc32="0xC3BBB270" />
+        <file offset="6" name="epr-20917.17" crc32="0x969E4BDA" />
       </region>
       <region name="banked_crom" stride="8" chunk_size="2" byte_swap="true">
         <!-- CROM0 -->


### PR DESCRIPTION
merge new dump hash from MAME 0.289 update.
epr-20917.17 was bad dump for long time but now revised.

reference:
https://github.com/mamedev/mame/commit/c35bfdf3ec73d88d240362f443c7f18146b95d7f