### PR TITLE
Add new config key RomsDirectory to Supermodel.ini

### DIFF
--- a/Src/OSD/SDL/Gui.cpp
+++ b/Src/OSD/SDL/Gui.cpp
@@ -778,13 +778,14 @@ static void GUI(const ImGuiIO& io, Util::Config::Node& config, const std::map<st
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 }
 
-static std::string GetRomPath(int selectedGame, const std::map<std::string, Game>& games)
+static std::string GetRomPath(int selectedGame, const std::map<std::string, Game>& games, std::string romsDirectory)
 {
     if (selectedGame >= 0) {
         int index = 0;
+
         for (auto& g : games) {
             if (selectedGame == index) {
-                return (std::filesystem::path("ROMs") / (g.second.name + ".zip")).string();        // todo config rom directory? File dialog will be a bit more tricky cross platform but we can specifiy edit box for manual path entry        
+                return (std::filesystem::path(romsDirectory) / (g.second.name + ".zip")).string();      
             }
             index++;
         }
@@ -868,6 +869,8 @@ std::vector<std::string> RunGUI(const std::string& configPath, Util::Config::Nod
     ImGui_ImplOpenGL3_Init("#version 410");
 
     std::string xmlFile = config["GameXMLFile"].ValueAs<std::string>();
+    std::string romsDirectory = config["RomsDirectory"].ValueAs<std::string>();
+    
     GameLoader loader(xmlFile);
     auto& games = loader.GetGames();
     int selectedGame = -1;  // -1 means no selection
@@ -903,8 +906,9 @@ std::vector<std::string> RunGUI(const std::string& configPath, Util::Config::Nod
             break;
         }
     }
-
-    path = GetRomPath(selectedGame, games);
+    
+    path = GetRomPath(selectedGame, games, romsDirectory);
+    
     if (!path.empty()) {
         romFiles.emplace_back(path);
     }

--- a/Src/OSD/SDL/Main.cpp
+++ b/Src/OSD/SDL/Main.cpp
@@ -1505,6 +1505,7 @@ Util::Config::Node DefaultConfig()
   
   config.Set("GameXMLFile", s_gameXMLFilePath);
   config.Set("InitStateFile", "");
+  config.Set("RomsDirectory", "ROMs");
   // CModel3
   config.Set("PowerPCFrequency", 0u, "Core", 0u, 200u);
   config.Set("MultiThreaded", true,"Core");


### PR DESCRIPTION
**Rational**: When using Supermodel from it's GUI roms are currently searched only in a child ROMs/ folder. This is a problem in particular when Supermodel is installed from a system package manager (homebrew, pkg, apt etc). This change allows users to configure any path to be searched when launching roms from the GUI. It is not provided as a command line option, only as a key in Supermodel.ini.

Thanks 